### PR TITLE
main actor refresh + install

### DIFF
--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -271,9 +271,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       object: nil,
       queue: .main
     ) { [weak self] _ in
-      guard let self else { return }
-      self.refreshSpaceInfo()
-      self.menuBarController.scheduleRefresh(after: 0.2)
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.refreshSpaceInfo()
+        self.menuBarController.scheduleRefresh(after: 0.2)
+      }
     }
   }
 
@@ -291,7 +293,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       object: nil,
       queue: .main
     ) { [weak self] _ in
-      self?.menuBarController.scheduleRefresh(after: 0.1)
+      Task { @MainActor [weak self] in
+        self?.menuBarController.scheduleRefresh(after: 0.1)
+      }
     }
   }
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,8 @@ set -e
 PRODUCT_NAME="InstantSpaceSwitcher"
 BUILD_PATH=".build/release"
 APP_BUNDLE="${PRODUCT_NAME}.app"
+APP_PATH="$(pwd)/${APP_BUNDLE}"
+INSTALL_PATH="/Applications/${APP_BUNDLE}"
 
 swift build -c release --disable-sandbox
 
@@ -16,4 +18,12 @@ cp Info.plist "${APP_BUNDLE}/Contents/"
 echo "Signing..."
 codesign --force --deep --sign - "${APP_BUNDLE}"
 
-echo "App bundled at ${APP_BUNDLE}"
+if [[ "${1:-}" == "--install" ]]; then
+  echo "Installing to ${INSTALL_PATH}..."
+  rm -rf "${INSTALL_PATH}"
+  cp -R "${APP_BUNDLE}" "${INSTALL_PATH}"
+  echo "App installed at ${INSTALL_PATH}"
+else
+  echo "App bundled at ${APP_PATH}"
+  echo "Run './build.sh --install' to copy it to ${INSTALL_PATH}"
+fi


### PR DESCRIPTION
Problem
UI refresh work after space/app activation was not isolated to the main actor. The build script also stopped at bundling, so local installs required extra manual steps.

Fix
Run the notification-driven refresh paths inside `Task { @MainActor ... }` and add `./build.sh --install` to copy the app bundle into `/Applications`.