### PR TITLE
feat: override 3-finger swipe

### DIFF
--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -57,6 +57,15 @@ extern CGSSpaceID CGSGetActiveSpace(CGSConnectionID connection) __attribute__((w
 static CFMachPortRef globalTap = NULL;
 static CFRunLoopSourceRef globalSource = NULL;
 
+// Swipe override state
+static bool swipeOverrideEnabled = false;
+static bool swipeTracking = false;
+static bool swipeFired = false;
+
+// Number of our own synthetic events to pass through the tap without re-intercepting.
+// Incremented by iss_post_switch_gesture, decremented by the callback.
+static int passthrough_count = 0;
+
 static bool extract_space_info_from_display(CFDictionaryRef displayDict,
                                             CGSSpaceID activeSpace,
                                             bool hasActiveSpace,
@@ -66,12 +75,94 @@ static bool iss_post_switch_gesture(ISSDirection direction);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
 
-// Event tap callback (required but can be empty)
-static CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, 
+static CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type,
                                    CGEventRef event, void *refcon) {
     (void)proxy;
-    (void)type;
     (void)refcon;
+
+    // Re-enable if the system disabled our tap for being too slow
+    if (type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput) {
+        if (globalTap) CGEventTapEnable(globalTap, true);
+        return event;
+    }
+
+    if (!swipeOverrideEnabled) return event;
+
+    CGSEventType eventType =
+        (CGSEventType)CGEventGetIntegerValueField(event, kCGSEventTypeField);
+
+    // Pass through our own synthetic events (counted, not tagged — tags don't
+    // survive CGEventPost).
+    if (passthrough_count > 0
+        && (eventType == kCGSEventDockControl || eventType == kCGSEventGesture)) {
+        passthrough_count--;
+        return event;
+    }
+
+    if (eventType == kCGSEventDockControl) {
+        uint32_t hidType =
+            (uint32_t)CGEventGetIntegerValueField(event, kCGEventGestureHIDType);
+        if (hidType != kIOHIDEventTypeDockSwipe) return event;
+
+        uint16_t motion =
+            (uint16_t)CGEventGetIntegerValueField(event, kCGEventGestureSwipeMotion);
+        if (motion != kCGGestureMotionHorizontal) return event;
+
+        CGSGesturePhase phase =
+            (CGSGesturePhase)CGEventGetIntegerValueField(event, kCGEventGesturePhase);
+
+        switch (phase) {
+        case kCGSGesturePhaseBegan:
+            swipeTracking = true;
+            swipeFired = false;
+            return NULL;
+
+        case kCGSGesturePhaseChanged: {
+            if (!swipeTracking) return event;
+            if (!swipeFired) {
+                double progress =
+                    CGEventGetDoubleValueField(event, kCGEventGestureSwipeProgress);
+                if (progress != 0.0) {
+                    ISSDirection dir =
+                        progress > 0 ? ISSDirectionRight : ISSDirectionLeft;
+                    swipeFired = true;
+                    iss_switch(dir);
+                }
+            }
+            return NULL;
+        }
+
+        case kCGSGesturePhaseEnded: {
+            if (!swipeTracking) return event;
+            if (!swipeFired) {
+                double velocity =
+                    CGEventGetDoubleValueField(event, kCGEventGestureSwipeVelocityX);
+                if (velocity != 0.0) {
+                    ISSDirection dir =
+                        velocity > 0 ? ISSDirectionRight : ISSDirectionLeft;
+                    iss_switch(dir);
+                }
+            }
+            swipeTracking = false;
+            swipeFired = false;
+            return NULL;
+        }
+
+        case kCGSGesturePhaseCancelled:
+            swipeTracking = false;
+            swipeFired = false;
+            return NULL;
+
+        default:
+            return swipeTracking ? NULL : event;
+        }
+    }
+
+    // Suppress companion gesture events during active swipe tracking
+    if (eventType == kCGSEventGesture && swipeTracking) {
+        return NULL;
+    }
+
     return event;
 }
 
@@ -305,6 +396,7 @@ static bool iss_post_switch_gesture(ISSDirection direction) {
     // Cannot explain this
     CGEventSetDoubleValueField(evB, kCGEventGestureZoomDeltaX, FLT_TRUE_MIN);
 
+    passthrough_count += 4; // 2 pairs × (evA + evB)
     CGEventPost(kCGSessionEventTap, evB);
     CGEventPost(kCGSessionEventTap, evA);
     CFRelease(evA);
@@ -349,7 +441,8 @@ bool iss_init(void) {
         return true;
     }
 
-    CGEventMask mask = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp);
+    CGEventMask mask = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp)
+        | (1ULL << kCGSEventGesture) | (1ULL << kCGSEventDockControl);
     globalTap = CGEventTapCreate(
         kCGSessionEventTap,
         kCGHeadInsertEventTap,
@@ -450,4 +543,12 @@ bool iss_switch_to_index(unsigned int targetIndex) {
     }
 
     return !outOfBounds;
+}
+
+void iss_set_swipe_override(bool enabled) {
+    swipeOverrideEnabled = enabled;
+    if (!enabled) {
+        swipeTracking = false;
+        swipeFired = false;
+    }
 }

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,6 +66,8 @@ static bool swipeFired = false;
 // Incremented by iss_post_switch_gesture, decremented by the callback.
 static int passthrough_count = 0;
 
+static ISSSwipeHandler swipeHandler = NULL;
+
 static bool extract_space_info_from_display(CFDictionaryRef displayDict,
                                             CGSSpaceID activeSpace,
                                             bool hasActiveSpace,
@@ -74,6 +76,28 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
 static bool iss_post_switch_gesture(ISSDirection direction);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
+
+// Perform a swipe-override switch: get space info, compute target, switch,
+// and notify the handler with the target index.
+static void swipe_override_switch(ISSDirection dir) {
+    ISSSpaceInfo info;
+    if (!iss_get_space_info(&info)) {
+        iss_post_switch_gesture(dir);
+        return;
+    }
+
+    unsigned int target;
+    if (dir == ISSDirectionLeft) {
+        target = info.currentIndex > 0 ? info.currentIndex - 1 : info.currentIndex;
+    } else {
+        target = info.currentIndex + 1 < info.spaceCount
+            ? info.currentIndex + 1 : info.currentIndex;
+    }
+
+    if (iss_switch_with_info(&info, dir) && swipeHandler) {
+        swipeHandler(target);
+    }
+}
 
 static CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type,
                                    CGEventRef event, void *refcon) {
@@ -126,7 +150,7 @@ static CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type,
                     ISSDirection dir =
                         progress > 0 ? ISSDirectionRight : ISSDirectionLeft;
                     swipeFired = true;
-                    iss_switch(dir);
+                    swipe_override_switch(dir);
                 }
             }
             return NULL;
@@ -140,7 +164,7 @@ static CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type,
                 if (velocity != 0.0) {
                     ISSDirection dir =
                         velocity > 0 ? ISSDirectionRight : ISSDirectionLeft;
-                    iss_switch(dir);
+                    swipe_override_switch(dir);
                 }
             }
             swipeTracking = false;
@@ -551,4 +575,8 @@ void iss_set_swipe_override(bool enabled) {
         swipeTracking = false;
         swipeFired = false;
     }
+}
+
+void iss_set_swipe_handler(ISSSwipeHandler handler) {
+    swipeHandler = handler;
 }

--- a/Sources/ISS/include/ISS.h
+++ b/Sources/ISS/include/ISS.h
@@ -61,4 +61,13 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction);
  */
 bool iss_switch_to_index(unsigned int targetIndex);
 
+/**
+ * @brief Enables or disables interception of trackpad 3-finger swipe gestures.
+ *
+ * When enabled, native horizontal dock-swipe gestures are suppressed and
+ * replaced with instant space switches (no sliding animation).
+ * @param enabled true to intercept, false to pass gestures through normally.
+ */
+void iss_set_swipe_override(bool enabled);
+
 #endif /* ISS_h */

--- a/Sources/ISS/include/ISS.h
+++ b/Sources/ISS/include/ISS.h
@@ -70,4 +70,16 @@ bool iss_switch_to_index(unsigned int targetIndex);
  */
 void iss_set_swipe_override(bool enabled);
 
+/**
+ * @brief Callback invoked after a swipe-override switch succeeds.
+ * @param targetIndex Zero-based index of the space that was switched to.
+ */
+typedef void (*ISSSwipeHandler)(unsigned int targetIndex);
+
+/**
+ * @brief Registers a handler called after each successful swipe-override switch.
+ * @param handler Function pointer, or NULL to clear.
+ */
+void iss_set_swipe_handler(ISSSwipeHandler handler);
+
 #endif /* ISS_h */

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -19,6 +19,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       print("Failed to initialize ISS event tap")
     }
 
+    if UserDefaults.standard.bool(forKey: "swipeOverride") {
+      iss_set_swipe_override(true)
+    }
+
     setupMainMenu()
     menuBarController.delegate = self
     menuBarController.setup()

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -23,6 +23,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       iss_set_swipe_override(true)
     }
 
+    iss_set_swipe_handler { targetIndex in
+      DispatchQueue.main.async {
+        OSDWindow.shared.show(message: "\(targetIndex + 1)")
+      }
+    }
+
     setupMainMenu()
     menuBarController.delegate = self
     menuBarController.setup()

--- a/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ISS
 import ServiceManagement
 
 final class GeneralSettingsViewController: NSViewController {
@@ -6,6 +7,8 @@ final class GeneralSettingsViewController: NSViewController {
     checkboxWithTitle: "Show on-screen display when switching spaces", target: nil, action: nil)
   private let osdDurationPopup = NSPopUpButton()
   private let osdDurationLabel = NSTextField(labelWithString: "Duration:")
+  private let swipeOverrideCheckbox = NSButton(
+    checkboxWithTitle: "Override 3-finger swipe for instant switching", target: nil, action: nil)
   private let launchAtLoginCheckbox = NSButton(
     checkboxWithTitle: "Launch at login", target: nil, action: nil)
 
@@ -49,12 +52,16 @@ final class GeneralSettingsViewController: NSViewController {
     osdDurationContainer.addArrangedSubview(osdDurationLabel)
     osdDurationContainer.addArrangedSubview(osdDurationPopup)
 
+    swipeOverrideCheckbox.target = self
+    swipeOverrideCheckbox.action = #selector(swipeOverrideChanged)
+
     launchAtLoginCheckbox.target = self
     launchAtLoginCheckbox.action = #selector(launchAtLoginChanged)
 
     stackView.addArrangedSubview(generalLabel)
     stackView.addArrangedSubview(showOSDCheckbox)
     stackView.addArrangedSubview(osdDurationContainer)
+    stackView.addArrangedSubview(swipeOverrideCheckbox)
     stackView.addArrangedSubview(launchAtLoginCheckbox)
 
     view.addSubview(stackView)
@@ -79,6 +86,8 @@ final class GeneralSettingsViewController: NSViewController {
 
     osdDurationPopup.isEnabled = showOSD
 
+    swipeOverrideCheckbox.state = defaults.bool(forKey: "swipeOverride") ? .on : .off
+
     launchAtLoginCheckbox.state = SMAppService.mainApp.status == .enabled ? .on : .off
   }
 
@@ -93,6 +102,12 @@ final class GeneralSettingsViewController: NSViewController {
     guard index >= 0 && index < durationPresets.count else { return }
     let duration = durationPresets[index]
     defaults.set(duration, forKey: "osdDurationMs")
+  }
+
+  @objc private func swipeOverrideChanged(_ sender: NSButton) {
+    let isEnabled = sender.state == .on
+    defaults.set(isEnabled, forKey: "swipeOverride")
+    iss_set_swipe_override(isEnabled)
   }
 
   @objc private func launchAtLoginChanged(_ sender: NSButton) {


### PR DESCRIPTION
Intercepts macOS's native trackpad 3-finger horizontal swipe and replaces
the slow sliding animation with the app's instant switch. The existing
CGEventTap is expanded to listen for dock-swipe gesture events — real
gestures are suppressed and replaced with synthetic high-velocity
switches. A passthrough counter prevents the tap from re-intercepting its
own posted events.

  - New checkbox in General Settings: "Override 3-finger swipe for instant
  switching"
  - OSD displays target space number on swipe-triggered switches
  - Vertical swipes (Mission Control, App Exposé) are unaffected