### PR TITLE
add custom space naming with multi-monitor support

### DIFF
--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -483,10 +483,24 @@ bool iss_get_all_displays_info(ISSAllDisplaysInfo *info) {
                 continue;
             }
 
-            // Found matching display — count its spaces
+            // Found matching display — count its spaces and extract IDs
             const void *spacesValue = CFDictionaryGetValue(entryDict, CFSTR("Spaces"));
             if (spacesValue && CFGetTypeID(spacesValue) == CFArrayGetTypeID()) {
-                info->spaceCounts[di] = (unsigned int)CFArrayGetCount((CFArrayRef)spacesValue);
+                CFArrayRef spaces = (CFArrayRef)spacesValue;
+                unsigned int count = (unsigned int)CFArrayGetCount(spaces);
+                info->spaceCounts[di] = count;
+                unsigned int stored = count < ISS_MAX_SPACES_PER_DISPLAY ? count : ISS_MAX_SPACES_PER_DISPLAY;
+                for (unsigned int si = 0; si < stored; si++) {
+                    info->spaceIDs[di][si] = 0;
+                    const void *sv = CFArrayGetValueAtIndex(spaces, si);
+                    if (!sv || CFGetTypeID(sv) != CFDictionaryGetTypeID()) continue;
+                    CFNumberRef idNum = (CFNumberRef)CFDictionaryGetValue((CFDictionaryRef)sv, CFSTR("id64"));
+                    if (idNum && CFGetTypeID(idNum) == CFNumberGetTypeID()) {
+                        int64_t val = 0;
+                        CFNumberGetValue(idNum, kCFNumberSInt64Type, &val);
+                        info->spaceIDs[di][si] = (uint64_t)val;
+                    }
+                }
             }
             break;
         }
@@ -515,6 +529,60 @@ uint32_t iss_get_cursor_display_id(void) {
     }
 
     return 0;
+}
+
+bool iss_get_cursor_display_space_ids(uint64_t *spaceIDs, unsigned int maxCount, unsigned int *outCount) {
+    if (!spaceIDs || !outCount || maxCount == 0) return false;
+    *outCount = 0;
+
+    if (!cgs_symbols_available()) return false;
+    CGSConnectionID connection = CGSMainConnectionID();
+    if (connection == 0) return false;
+
+    uint32_t cursorDisplayID = iss_get_cursor_display_id();
+    if (cursorDisplayID == 0) return false;
+    CFUUIDRef displayUUID = CGDisplayCreateUUIDFromDisplayID(cursorDisplayID);
+    if (!displayUUID) return false;
+    CFStringRef displayIDStr = CFUUIDCreateString(NULL, displayUUID);
+    CFRelease(displayUUID);
+    if (!displayIDStr) return false;
+
+    CFArrayRef allDisplayData = CGSCopyManagedDisplaySpaces(connection, NULL);
+    if (!allDisplayData) { CFRelease(displayIDStr); return false; }
+
+    bool success = false;
+    const CFIndex entryCount = CFArrayGetCount(allDisplayData);
+    for (CFIndex ei = 0; ei < entryCount; ei++) {
+        const void *entryValue = CFArrayGetValueAtIndex(allDisplayData, ei);
+        if (!entryValue || CFGetTypeID(entryValue) != CFDictionaryGetTypeID()) continue;
+        CFDictionaryRef entryDict = (CFDictionaryRef)entryValue;
+        CFStringRef identifier = (CFStringRef)CFDictionaryGetValue(entryDict, CFSTR("Display Identifier"));
+        if (!identifier || !CFEqual(identifier, displayIDStr)) continue;
+
+        const void *spacesValue = CFDictionaryGetValue(entryDict, CFSTR("Spaces"));
+        if (!spacesValue || CFGetTypeID(spacesValue) != CFArrayGetTypeID()) break;
+        CFArrayRef spaces = (CFArrayRef)spacesValue;
+        unsigned int count = (unsigned int)CFArrayGetCount(spaces);
+        unsigned int stored = count < maxCount ? count : maxCount;
+        for (unsigned int si = 0; si < stored; si++) {
+            spaceIDs[si] = 0;
+            const void *sv = CFArrayGetValueAtIndex(spaces, si);
+            if (!sv || CFGetTypeID(sv) != CFDictionaryGetTypeID()) continue;
+            CFNumberRef idNum = (CFNumberRef)CFDictionaryGetValue((CFDictionaryRef)sv, CFSTR("id64"));
+            if (idNum && CFGetTypeID(idNum) == CFNumberGetTypeID()) {
+                int64_t val = 0;
+                CFNumberGetValue(idNum, kCFNumberSInt64Type, &val);
+                spaceIDs[si] = (uint64_t)val;
+            }
+        }
+        *outCount = stored;
+        success = true;
+        break;
+    }
+
+    CFRelease(allDisplayData);
+    CFRelease(displayIDStr);
+    return success;
 }
 
 bool iss_switch_to_index(unsigned int targetIndex) {

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -421,6 +421,102 @@ bool iss_switch(ISSDirection direction) {
     return iss_post_switch_gesture(direction);
 }
 
+bool iss_get_all_displays_info(ISSAllDisplaysInfo *info) {
+    if (!info) {
+        return false;
+    }
+    memset(info, 0, sizeof(*info));
+
+    if (!cgs_symbols_available()) {
+        return false;
+    }
+
+    CGSConnectionID connection = CGSMainConnectionID();
+    if (connection == 0) {
+        return false;
+    }
+
+    CGDirectDisplayID activeDisplays[ISS_MAX_DISPLAYS];
+    uint32_t activeDisplayCount = 0;
+    if (CGGetActiveDisplayList(ISS_MAX_DISPLAYS, activeDisplays, &activeDisplayCount) != kCGErrorSuccess
+        || activeDisplayCount == 0) {
+        return false;
+    }
+
+    // Get all display space data in one call
+    CFArrayRef allDisplayData = CGSCopyManagedDisplaySpaces(connection, NULL);
+    if (!allDisplayData) {
+        return false;
+    }
+
+    info->displayCount = activeDisplayCount > ISS_MAX_DISPLAYS ? ISS_MAX_DISPLAYS : activeDisplayCount;
+
+    for (uint32_t di = 0; di < info->displayCount; di++) {
+        info->displayIDs[di] = activeDisplays[di];
+
+        // Convert CGDirectDisplayID to UUID string to match against display data
+        CFUUIDRef displayUUID = CGDisplayCreateUUIDFromDisplayID(activeDisplays[di]);
+        if (!displayUUID) {
+            continue;
+        }
+        CFStringRef displayIDStr = CFUUIDCreateString(NULL, displayUUID);
+        CFRelease(displayUUID);
+        if (!displayIDStr) {
+            continue;
+        }
+
+        // Find matching display entry by "Display Identifier"
+        const CFIndex entryCount = CFArrayGetCount(allDisplayData);
+        for (CFIndex ei = 0; ei < entryCount; ei++) {
+            const void *entryValue = CFArrayGetValueAtIndex(allDisplayData, ei);
+            if (!entryValue || CFGetTypeID(entryValue) != CFDictionaryGetTypeID()) {
+                continue;
+            }
+
+            CFDictionaryRef entryDict = (CFDictionaryRef)entryValue;
+            CFStringRef identifier = (CFStringRef)CFDictionaryGetValue(entryDict, CFSTR("Display Identifier"));
+            if (!identifier || CFGetTypeID(identifier) != CFStringGetTypeID()) {
+                continue;
+            }
+
+            if (!CFEqual(identifier, displayIDStr)) {
+                continue;
+            }
+
+            // Found matching display — count its spaces
+            const void *spacesValue = CFDictionaryGetValue(entryDict, CFSTR("Spaces"));
+            if (spacesValue && CFGetTypeID(spacesValue) == CFArrayGetTypeID()) {
+                info->spaceCounts[di] = (unsigned int)CFArrayGetCount((CFArrayRef)spacesValue);
+            }
+            break;
+        }
+
+        CFRelease(displayIDStr);
+    }
+
+    CFRelease(allDisplayData);
+    return true;
+}
+
+uint32_t iss_get_cursor_display_id(void) {
+    CGEventRef tempEvent = CGEventCreate(NULL);
+    if (!tempEvent) {
+        return 0;
+    }
+    CGPoint cursorLocation = CGEventGetLocation(tempEvent);
+    CFRelease(tempEvent);
+
+    CGDirectDisplayID cursorDisplay = 0;
+    uint32_t displayCount = 0;
+
+    if (CGGetDisplaysWithPoint(cursorLocation, 1, &cursorDisplay, &displayCount) == kCGErrorSuccess
+        && displayCount > 0) {
+        return cursorDisplay;
+    }
+
+    return 0;
+}
+
 bool iss_switch_to_index(unsigned int targetIndex) {
     ISSSpaceInfo info;
     if (!iss_get_space_info(&info)) {

--- a/Sources/ISS/include/ISS.h
+++ b/Sources/ISS/include/ISS.h
@@ -63,14 +63,16 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction);
 bool iss_switch_to_index(unsigned int targetIndex);
 
 #define ISS_MAX_DISPLAYS 8
+#define ISS_MAX_SPACES_PER_DISPLAY 20
 
 /**
- * @brief Space counts for all connected displays.
+ * @brief Space counts for all connected displays, including stable space IDs.
  */
 typedef struct {
     unsigned int displayCount;
     unsigned int spaceCounts[ISS_MAX_DISPLAYS];
     uint32_t displayIDs[ISS_MAX_DISPLAYS];
+    uint64_t spaceIDs[ISS_MAX_DISPLAYS][ISS_MAX_SPACES_PER_DISPLAY];
 } ISSAllDisplaysInfo;
 
 /**
@@ -85,5 +87,14 @@ bool iss_get_all_displays_info(ISSAllDisplaysInfo *info);
  * @return The display ID, or 0 on failure.
  */
 uint32_t iss_get_cursor_display_id(void);
+
+/**
+ * @brief Retrieves the space IDs for the display under the cursor.
+ * @param spaceIDs Output array to receive space IDs.
+ * @param maxCount Maximum number of IDs to store.
+ * @param outCount Output pointer that receives the actual number of space IDs.
+ * @return true on success, false on failure.
+ */
+bool iss_get_cursor_display_space_ids(uint64_t *spaceIDs, unsigned int maxCount, unsigned int *outCount);
 
 #endif /* ISS_h */

--- a/Sources/ISS/include/ISS.h
+++ b/Sources/ISS/include/ISS.h
@@ -2,6 +2,7 @@
 #define ISS_h
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /** @brief Initialize resources
  * @return true on success, false on failure
@@ -60,5 +61,29 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction);
  * @return true if the request succeeded (already on target or switches posted)
  */
 bool iss_switch_to_index(unsigned int targetIndex);
+
+#define ISS_MAX_DISPLAYS 8
+
+/**
+ * @brief Space counts for all connected displays.
+ */
+typedef struct {
+    unsigned int displayCount;
+    unsigned int spaceCounts[ISS_MAX_DISPLAYS];
+    uint32_t displayIDs[ISS_MAX_DISPLAYS];
+} ISSAllDisplaysInfo;
+
+/**
+ * @brief Retrieves space counts for every active display.
+ * @param info Output pointer that receives the info struct.
+ * @return true on success, false on failure.
+ */
+bool iss_get_all_displays_info(ISSAllDisplaysInfo *info);
+
+/**
+ * @brief Returns the CGDirectDisplayID for the display under the cursor.
+ * @return The display ID, or 0 on failure.
+ */
+uint32_t iss_get_cursor_display_id(void);
 
 #endif /* ISS_h */

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -216,7 +216,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Get current space info for cursor display BEFORE switch to calculate target
     var info = ISSSpaceInfo()
     let hasInfo = iss_get_space_info(&info)
-    let cursorDisplayID = iss_get_cursor_display_id()
+    let spaceIDs = Self.cursorDisplaySpaceIDs()
 
     // Calculate target before attempting switch
     var targetIndex: UInt32 = 0
@@ -239,14 +239,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Show OSD with target space name on successful switch
     if hasInfo {
+      let targetIdx = Int(targetIndex)
+      let spaceID = targetIdx < spaceIDs.count ? spaceIDs[targetIdx] : 0
       let name = SpaceNameStore.shared.displayName(
-        forDisplayID: cursorDisplayID, spaceIndex: Int(targetIndex))
+        forSpaceID: spaceID, fallbackIndex: targetIdx)
       OSDWindow.shared.show(message: name)
     }
   }
 
   private func performSpaceSwitchToIndex(_ index: UInt32) {
-    let cursorDisplayID = iss_get_cursor_display_id()
+    let spaceIDs = Self.cursorDisplaySpaceIDs()
 
     if !iss_switch_to_index(index) {
       NSSound.beep()
@@ -257,9 +259,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     refreshSpaceInfo()
 
     // Show OSD with target space name
+    let idx = Int(index)
+    let spaceID = idx < spaceIDs.count ? spaceIDs[idx] : 0
     let name = SpaceNameStore.shared.displayName(
-      forDisplayID: cursorDisplayID, spaceIndex: Int(index))
+      forSpaceID: spaceID, fallbackIndex: idx)
     OSDWindow.shared.show(message: name)
+  }
+
+  /// Returns the stable macOS space IDs for all spaces on the cursor's display.
+  static func cursorDisplaySpaceIDs() -> [UInt64] {
+    var ids = [UInt64](repeating: 0, count: Int(ISS_MAX_SPACES_PER_DISPLAY))
+    var count: UInt32 = 0
+    guard iss_get_cursor_display_space_ids(&ids, UInt32(ids.count), &count) else { return [] }
+    return Array(ids.prefix(Int(count)))
   }
 
   private func refreshSpaceInfo() {

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -216,6 +216,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Get current space info for cursor display BEFORE switch to calculate target
     var info = ISSSpaceInfo()
     let hasInfo = iss_get_space_info(&info)
+    let cursorDisplayID = iss_get_cursor_display_id()
 
     // Calculate target before attempting switch
     var targetIndex: UInt32 = 0
@@ -236,13 +237,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Update menubar space info only on successful switch
     refreshSpaceInfo()
 
-    // Show OSD with target space number only on successful switch
+    // Show OSD with target space name on successful switch
     if hasInfo {
-      OSDWindow.shared.show(message: "\(targetIndex + 1)")
+      let name = SpaceNameStore.shared.displayName(
+        forDisplayID: cursorDisplayID, spaceIndex: Int(targetIndex))
+      OSDWindow.shared.show(message: name)
     }
   }
 
   private func performSpaceSwitchToIndex(_ index: UInt32) {
+    let cursorDisplayID = iss_get_cursor_display_id()
+
     if !iss_switch_to_index(index) {
       NSSound.beep()
       return
@@ -251,8 +256,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // Update menubar space info
     refreshSpaceInfo()
 
-    // Show OSD with target space number only
-    OSDWindow.shared.show(message: "\(index + 1)")
+    // Show OSD with target space name
+    let name = SpaceNameStore.shared.displayName(
+      forDisplayID: cursorDisplayID, spaceIndex: Int(index))
+    OSDWindow.shared.show(message: name)
   }
 
   private func refreshSpaceInfo() {

--- a/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
+++ b/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
@@ -143,9 +143,12 @@ final class MenuBarController: NSObject, NSMenuDelegate {
       return
     }
 
+    // Menu bar shows spaces for the cursor's current display
+    let displayID = iss_get_cursor_display_id()
     let count = Int(info.spaceCount)
     for index in 0..<count {
-      let title = "Space \(index + 1)"
+      let customName = SpaceNameStore.shared.name(forDisplayID: displayID, spaceIndex: index)
+      let title = customName ?? "Space \(index + 1)"
       let item = NSMenuItem(title: title, action: #selector(switchToSpace(_:)), keyEquivalent: "")
       item.tag = index
       item.target = self

--- a/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
+++ b/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
@@ -144,10 +144,11 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     // Menu bar shows spaces for the cursor's current display
-    let displayID = iss_get_cursor_display_id()
+    let spaceIDs = AppDelegate.cursorDisplaySpaceIDs()
     let count = Int(info.spaceCount)
     for index in 0..<count {
-      let customName = SpaceNameStore.shared.name(forDisplayID: displayID, spaceIndex: index)
+      let spaceID = index < spaceIDs.count ? spaceIDs[index] : 0
+      let customName = SpaceNameStore.shared.name(forSpaceID: spaceID)
       let title = customName ?? "Space \(index + 1)"
       let item = NSMenuItem(title: title, action: #selector(switchToSpace(_:)), keyEquivalent: "")
       item.tag = index

--- a/Sources/InstantSpaceSwitcher/Hotkeys/SpaceNameStore.swift
+++ b/Sources/InstantSpaceSwitcher/Hotkeys/SpaceNameStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+final class SpaceNameStore {
+  static let shared = SpaceNameStore()
+
+  private let defaults = UserDefaults.standard
+  private let keyPrefix = "spaceName."
+  private let maxTrackedSpacesPerDisplay = 20
+
+  private init() {}
+
+  // MARK: - Per-display naming
+
+  func name(forDisplayID displayID: UInt32, spaceIndex index: Int) -> String? {
+    let value = defaults.string(forKey: "\(keyPrefix)\(displayID).\(index + 1)")
+    guard let value, !value.isEmpty else { return nil }
+    return value
+  }
+
+  func setName(_ name: String?, forDisplayID displayID: UInt32, spaceIndex index: Int) {
+    defaults.set(name, forKey: "\(keyPrefix)\(displayID).\(index + 1)")
+  }
+
+  /// Returns the custom name if set, otherwise the 1-based space number.
+  func displayName(forDisplayID displayID: UInt32, spaceIndex index: Int) -> String {
+    name(forDisplayID: displayID, spaceIndex: index) ?? "\(index + 1)"
+  }
+
+  /// Clears names for spaces beyond the given count on a specific display.
+  func clearNames(forDisplayID displayID: UInt32, beyondCount count: Int) {
+    for i in (count + 1)...maxTrackedSpacesPerDisplay {
+      defaults.removeObject(forKey: "\(keyPrefix)\(displayID).\(i)")
+    }
+  }
+
+  /// Clears all names for a specific display.
+  func clearNames(forDisplayID displayID: UInt32) {
+    for i in 1...maxTrackedSpacesPerDisplay {
+      defaults.removeObject(forKey: "\(keyPrefix)\(displayID).\(i)")
+    }
+  }
+
+  func resetAll() {
+    // Clear all keys matching our prefix
+    for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(keyPrefix) {
+      defaults.removeObject(forKey: key)
+    }
+  }
+
+}

--- a/Sources/InstantSpaceSwitcher/Hotkeys/SpaceNameStore.swift
+++ b/Sources/InstantSpaceSwitcher/Hotkeys/SpaceNameStore.swift
@@ -4,47 +4,33 @@ final class SpaceNameStore {
   static let shared = SpaceNameStore()
 
   private let defaults = UserDefaults.standard
-  private let keyPrefix = "spaceName."
-  private let maxTrackedSpacesPerDisplay = 20
+  private let keyPrefix = "spaceNameByID."
 
   private init() {}
 
-  // MARK: - Per-display naming
+  // MARK: - Per-space naming (keyed by stable macOS space ID)
 
-  func name(forDisplayID displayID: UInt32, spaceIndex index: Int) -> String? {
-    let value = defaults.string(forKey: "\(keyPrefix)\(displayID).\(index + 1)")
+  func name(forSpaceID spaceID: UInt64) -> String? {
+    guard spaceID != 0 else { return nil }
+    let value = defaults.string(forKey: "\(keyPrefix)\(spaceID)")
     guard let value, !value.isEmpty else { return nil }
     return value
   }
 
-  func setName(_ name: String?, forDisplayID displayID: UInt32, spaceIndex index: Int) {
-    defaults.set(name, forKey: "\(keyPrefix)\(displayID).\(index + 1)")
+  func setName(_ name: String?, forSpaceID spaceID: UInt64) {
+    guard spaceID != 0 else { return }
+    defaults.set(name, forKey: "\(keyPrefix)\(spaceID)")
   }
 
   /// Returns the custom name if set, otherwise the 1-based space number.
-  func displayName(forDisplayID displayID: UInt32, spaceIndex index: Int) -> String {
-    name(forDisplayID: displayID, spaceIndex: index) ?? "\(index + 1)"
-  }
-
-  /// Clears names for spaces beyond the given count on a specific display.
-  func clearNames(forDisplayID displayID: UInt32, beyondCount count: Int) {
-    for i in (count + 1)...maxTrackedSpacesPerDisplay {
-      defaults.removeObject(forKey: "\(keyPrefix)\(displayID).\(i)")
-    }
-  }
-
-  /// Clears all names for a specific display.
-  func clearNames(forDisplayID displayID: UInt32) {
-    for i in 1...maxTrackedSpacesPerDisplay {
-      defaults.removeObject(forKey: "\(keyPrefix)\(displayID).\(i)")
-    }
+  func displayName(forSpaceID spaceID: UInt64, fallbackIndex index: Int) -> String {
+    name(forSpaceID: spaceID) ?? "\(index + 1)"
   }
 
   func resetAll() {
-    // Clear all keys matching our prefix
-    for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(keyPrefix) {
+    for key in defaults.dictionaryRepresentation().keys
+    where key.hasPrefix(keyPrefix) || key.hasPrefix("spaceName.") {
       defaults.removeObject(forKey: key)
     }
   }
-
 }

--- a/Sources/InstantSpaceSwitcher/UI/OSDWindow.swift
+++ b/Sources/InstantSpaceSwitcher/UI/OSDWindow.swift
@@ -21,17 +21,43 @@ final class OSDWindow {
 
     guard let window = window, let label = label else { return }
 
+    // Adjust font size based on message length
+    let fontSize: CGFloat
+    switch message.count {
+    case 0...2: fontSize = 48
+    case 3...6: fontSize = 32
+    default: fontSize = 24
+    }
+    label.font = NSFont.systemFont(ofSize: fontSize, weight: .medium)
     label.stringValue = message
 
-    // Position on cursor's screen
-    let windowSize: CGFloat = 140
+    // Calculate window size based on text content
+    let padding: CGFloat = 24
+    let minSize: CGFloat = 140
+    let maxWidth: CGFloat = 300
+    let minHeight: CGFloat = 140
+
+    // Measure single-line width first (extra 8pt buffer for text field internal margins)
+    let singleLineSize = label.attributedStringValue.size()
+    let windowWidth = min(max(ceil(singleLineSize.width) + padding * 2 + 8, minSize), maxWidth)
+
+    // Measure wrapped height within the chosen width
+    let labelWidth = windowWidth - padding * 2
+    let boundingRect = label.attributedStringValue.boundingRect(
+      with: NSSize(width: labelWidth, height: .greatestFiniteMagnitude),
+      options: [.usesLineFragmentOrigin, .usesFontLeading])
+    let windowHeight = max(boundingRect.height + padding * 2, minHeight)
+
+    window.setContentSize(NSSize(width: windowWidth, height: windowHeight))
+
+    // Position centered on cursor's screen
     let mouseLocation = NSEvent.mouseLocation
     let screen =
       NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) ?? NSScreen.main
     if let screen = screen {
       let screenFrame = screen.visibleFrame
-      let x = screenFrame.midX - windowSize / 2
-      let y = screenFrame.midY - windowSize / 2
+      let x = screenFrame.midX - windowWidth / 2
+      let y = screenFrame.midY - windowHeight / 2
       window.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
@@ -64,15 +90,16 @@ final class OSDWindow {
     window.hidesOnDeactivate = false
 
     // Use vibrancy for native macOS look
-    let visualEffect = NSVisualEffectView(
-      frame: NSRect(x: 0, y: 0, width: windowSize, height: windowSize))
+    let visualEffect = NSVisualEffectView()
     visualEffect.material = .hudWindow
     visualEffect.state = .active
     visualEffect.wantsLayer = true
     visualEffect.layer?.cornerRadius = 18
     visualEffect.layer?.masksToBounds = true
+    visualEffect.autoresizingMask = [.width, .height]
+    visualEffect.frame = NSRect(x: 0, y: 0, width: windowSize, height: windowSize)
 
-    let label = NSTextField(labelWithString: "")
+    let label = NSTextField(wrappingLabelWithString: "")
     label.font = NSFont.systemFont(ofSize: 48, weight: .medium)
     label.textColor = .labelColor
     label.alignment = .center
@@ -80,6 +107,8 @@ final class OSDWindow {
     label.drawsBackground = false
     label.isBordered = false
     label.isEditable = false
+    label.maximumNumberOfLines = 0
+    label.lineBreakMode = .byWordWrapping
 
     visualEffect.addSubview(label)
     window.contentView = visualEffect
@@ -87,6 +116,8 @@ final class OSDWindow {
     NSLayoutConstraint.activate([
       label.centerXAnchor.constraint(equalTo: visualEffect.centerXAnchor),
       label.centerYAnchor.constraint(equalTo: visualEffect.centerYAnchor),
+      label.leadingAnchor.constraint(greaterThanOrEqualTo: visualEffect.leadingAnchor, constant: 24),
+      label.trailingAnchor.constraint(lessThanOrEqualTo: visualEffect.trailingAnchor, constant: -24),
     ])
 
     self.window = window

--- a/Sources/InstantSpaceSwitcher/UI/PreferencesTabViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/PreferencesTabViewController.swift
@@ -14,7 +14,14 @@ final class PreferencesTabViewController: NSTabViewController {
     shortcutsTab.label = "Keyboard"
     shortcutsTab.image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Keyboard")
 
+    let spacesTab = NSTabViewItem(viewController: SpaceNamesViewController())
+    spacesTab.label = "Spaces"
+    spacesTab.image = NSImage(
+      systemSymbolName: "square.and.line.vertical.and.square",
+      accessibilityDescription: "Spaces")
+
     addTabViewItem(generalTab)
     addTabViewItem(shortcutsTab)
+    addTabViewItem(spacesTab)
   }
 }

--- a/Sources/InstantSpaceSwitcher/UI/SpaceNamesViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/SpaceNamesViewController.swift
@@ -9,8 +9,8 @@ final class SpaceNamesViewController: NSViewController {
 
   /// Each entry is either a display header or a space row.
   private enum Row {
-    case displayHeader(displayIndex: Int, displayID: UInt32)
-    case space(displayID: UInt32, spaceIndex: Int)
+    case displayHeader(displayIndex: Int)
+    case space(spaceID: UInt64, spaceIndex: Int)
   }
 
   private var rows: [Row] = []
@@ -47,20 +47,18 @@ final class SpaceNamesViewController: NSViewController {
     let displayCount = Int(info.displayCount)
 
     for di in 0..<displayCount {
-      let displayID = withUnsafePointer(to: &info.displayIDs) {
-        $0.withMemoryRebound(to: UInt32.self, capacity: Int(ISS_MAX_DISPLAYS)) { $0[di] }
-      }
       let spaceCount = withUnsafePointer(to: &info.spaceCounts) {
         Int($0.withMemoryRebound(to: UInt32.self, capacity: Int(ISS_MAX_DISPLAYS)) { $0[di] })
       }
 
-      newRows.append(.displayHeader(displayIndex: di, displayID: displayID))
+      newRows.append(.displayHeader(displayIndex: di))
       for si in 0..<spaceCount {
-        newRows.append(.space(displayID: displayID, spaceIndex: si))
+        let spaceID = withUnsafeBytes(of: &info.spaceIDs) { rawBuf in
+          let base = rawBuf.baseAddress!.assumingMemoryBound(to: UInt64.self)
+          return base[di * Int(ISS_MAX_SPACES_PER_DISPLAY) + si]
+        }
+        newRows.append(.space(spaceID: spaceID, spaceIndex: si))
       }
-
-      // Clear stale names beyond current space count
-      store.clearNames(forDisplayID: displayID, beyondCount: spaceCount)
     }
 
     // Only reload if structure changed
@@ -138,8 +136,7 @@ extension SpaceNamesViewController: NSTableViewDelegate {
     let entry = rows[row]
 
     switch entry {
-    case .displayHeader(let displayIndex, _):
-      // Group rows span all columns — only called once with tableColumn == nil or first column
+    case .displayHeader(let displayIndex):
       guard tableColumn == nil || tableColumn?.identifier.rawValue == "name" else { return nil }
       let cellView = NSTableCellView()
       let label = NSTextField(labelWithString: "Display \(displayIndex + 1)")
@@ -170,10 +167,10 @@ extension SpaceNamesViewController: NSTableViewDelegate {
 
         return cellView
       } else if tableColumn?.identifier.rawValue == "customName" {
-        guard case .space(let displayID, let spaceIndex) = entry else { return nil }
+        guard case .space(let spaceID, _) = entry else { return nil }
         let cellView = NSTableCellView()
         let textField = NSTextField()
-        textField.stringValue = store.name(forDisplayID: displayID, spaceIndex: spaceIndex) ?? ""
+        textField.stringValue = store.name(forSpaceID: spaceID) ?? ""
         textField.placeholderString = "Enter name\u{2026}"
         textField.isBordered = false
         textField.drawsBackground = false
@@ -206,8 +203,8 @@ extension SpaceNamesViewController: NSTextFieldDelegate {
     guard let textField = notification.object as? NSTextField else { return }
     let rowIndex = textField.tag
     guard rowIndex >= 0 && rowIndex < rows.count else { return }
-    guard case .space(let displayID, let spaceIndex) = rows[rowIndex] else { return }
+    guard case .space(let spaceID, _) = rows[rowIndex] else { return }
     let value = textField.stringValue.trimmingCharacters(in: .whitespaces)
-    store.setName(value.isEmpty ? nil : value, forDisplayID: displayID, spaceIndex: spaceIndex)
+    store.setName(value.isEmpty ? nil : value, forSpaceID: spaceID)
   }
 }

--- a/Sources/InstantSpaceSwitcher/UI/SpaceNamesViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/SpaceNamesViewController.swift
@@ -1,0 +1,213 @@
+import AppKit
+import ISS
+
+final class SpaceNamesViewController: NSViewController {
+  private let store = SpaceNameStore.shared
+  private let tableView = NSTableView()
+  private let scrollView = NSScrollView()
+  private var pollTimer: Timer?
+
+  /// Each entry is either a display header or a space row.
+  private enum Row {
+    case displayHeader(displayIndex: Int, displayID: UInt32)
+    case space(displayID: UInt32, spaceIndex: Int)
+  }
+
+  private var rows: [Row] = []
+
+  override func loadView() {
+    view = NSView(frame: NSRect(x: 0, y: 0, width: 500, height: 300))
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupTableView()
+    refreshDisplayInfo()
+  }
+
+  override func viewWillAppear() {
+    super.viewWillAppear()
+    refreshDisplayInfo()
+    pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+      self?.refreshDisplayInfo()
+    }
+  }
+
+  override func viewWillDisappear() {
+    super.viewWillDisappear()
+    pollTimer?.invalidate()
+    pollTimer = nil
+  }
+
+  private func refreshDisplayInfo() {
+    var info = ISSAllDisplaysInfo()
+    guard iss_get_all_displays_info(&info) else { return }
+
+    var newRows: [Row] = []
+    let displayCount = Int(info.displayCount)
+
+    for di in 0..<displayCount {
+      let displayID = withUnsafePointer(to: &info.displayIDs) {
+        $0.withMemoryRebound(to: UInt32.self, capacity: Int(ISS_MAX_DISPLAYS)) { $0[di] }
+      }
+      let spaceCount = withUnsafePointer(to: &info.spaceCounts) {
+        Int($0.withMemoryRebound(to: UInt32.self, capacity: Int(ISS_MAX_DISPLAYS)) { $0[di] })
+      }
+
+      newRows.append(.displayHeader(displayIndex: di, displayID: displayID))
+      for si in 0..<spaceCount {
+        newRows.append(.space(displayID: displayID, spaceIndex: si))
+      }
+
+      // Clear stale names beyond current space count
+      store.clearNames(forDisplayID: displayID, beyondCount: spaceCount)
+    }
+
+    // Only reload if structure changed
+    if newRows.count != rows.count {
+      rows = newRows
+      tableView.reloadData()
+    } else {
+      rows = newRows
+    }
+  }
+
+  private func setupTableView() {
+    let nameColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("name"))
+    nameColumn.title = "Space"
+    nameColumn.width = 120
+    nameColumn.isEditable = false
+    tableView.addTableColumn(nameColumn)
+
+    let customNameColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("customName"))
+    customNameColumn.title = "Custom Name"
+    customNameColumn.width = 380
+    tableView.addTableColumn(customNameColumn)
+
+    tableView.delegate = self
+    tableView.dataSource = self
+    tableView.rowHeight = 28
+    tableView.usesAlternatingRowBackgroundColors = true
+    tableView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+
+    scrollView.documentView = tableView
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = false
+    scrollView.borderType = .bezelBorder
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+    let resetButton = NSButton(
+      title: "Reset All Names", target: self, action: #selector(resetAll))
+    resetButton.translatesAutoresizingMaskIntoConstraints = false
+
+    view.addSubview(scrollView)
+    view.addSubview(resetButton)
+
+    NSLayoutConstraint.activate([
+      scrollView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+      scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+      scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+      scrollView.bottomAnchor.constraint(equalTo: resetButton.topAnchor, constant: -12),
+
+      resetButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+      resetButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20),
+    ])
+  }
+
+  @objc private func resetAll() {
+    store.resetAll()
+    tableView.reloadData()
+  }
+}
+
+extension SpaceNamesViewController: NSTableViewDataSource {
+  func numberOfRows(in tableView: NSTableView) -> Int {
+    return rows.count
+  }
+}
+
+extension SpaceNamesViewController: NSTableViewDelegate {
+  func tableView(_ tableView: NSTableView, isGroupRow row: Int) -> Bool {
+    if case .displayHeader = rows[row] { return true }
+    return false
+  }
+
+  func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int)
+    -> NSView?
+  {
+    let entry = rows[row]
+
+    switch entry {
+    case .displayHeader(let displayIndex, _):
+      // Group rows span all columns — only called once with tableColumn == nil or first column
+      guard tableColumn == nil || tableColumn?.identifier.rawValue == "name" else { return nil }
+      let cellView = NSTableCellView()
+      let label = NSTextField(labelWithString: "Display \(displayIndex + 1)")
+      label.font = NSFont.boldSystemFont(ofSize: 13)
+      label.translatesAutoresizingMaskIntoConstraints = false
+      cellView.addSubview(label)
+
+      NSLayoutConstraint.activate([
+        label.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 4),
+        label.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
+      ])
+
+      return cellView
+
+    case .space(_, let spaceIndex):
+      if tableColumn?.identifier.rawValue == "name" {
+        let cellView = NSTableCellView()
+        let textField = NSTextField(labelWithString: "Space \(spaceIndex + 1)")
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        cellView.addSubview(textField)
+        cellView.textField = textField
+
+        NSLayoutConstraint.activate([
+          textField.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 16),
+          textField.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -4),
+          textField.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
+        ])
+
+        return cellView
+      } else if tableColumn?.identifier.rawValue == "customName" {
+        guard case .space(let displayID, let spaceIndex) = entry else { return nil }
+        let cellView = NSTableCellView()
+        let textField = NSTextField()
+        textField.stringValue = store.name(forDisplayID: displayID, spaceIndex: spaceIndex) ?? ""
+        textField.placeholderString = "Enter name\u{2026}"
+        textField.isBordered = false
+        textField.drawsBackground = false
+        textField.font = NSFont.systemFont(ofSize: 13)
+        textField.tag = row
+        textField.delegate = self
+        textField.cell?.isScrollable = true
+        textField.cell?.wraps = false
+        textField.cell?.lineBreakMode = .byClipping
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        cellView.addSubview(textField)
+        cellView.textField = textField
+
+        NSLayoutConstraint.activate([
+          textField.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 4),
+          textField.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -4),
+          textField.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
+        ])
+
+        return cellView
+      }
+    }
+
+    return nil
+  }
+}
+
+extension SpaceNamesViewController: NSTextFieldDelegate {
+  func controlTextDidEndEditing(_ notification: Notification) {
+    guard let textField = notification.object as? NSTextField else { return }
+    let rowIndex = textField.tag
+    guard rowIndex >= 0 && rowIndex < rows.count else { return }
+    guard case .space(let displayID, let spaceIndex) = rows[rowIndex] else { return }
+    let value = textField.stringValue.trimmingCharacters(in: .whitespaces)
+    store.setName(value.isEmpty ? nil : value, forDisplayID: displayID, spaceIndex: spaceIndex)
+  }
+}


### PR DESCRIPTION
Adds the ability to rename the pop up for spaces.

Dynamically reloads spaces as they are added and removed.

Supports multiple monitors. 

Related: #11 

https://github.com/user-attachments/assets/6d68aca2-41fd-4626-868a-c97a2e6c0e16

