### PR TITLE
Wrap switch right/left around to the other end

### DIFF
--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -231,17 +231,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let hasInfo = iss_get_space_info(&info)
 
     // Calculate target before attempting switch
+    let wrapAround = UserDefaults.standard.bool(forKey: "wrapAroundSpaces")
     var targetIndex: UInt32 = 0
+    var shouldWrap = false
     if hasInfo {
       if direction == ISSDirectionLeft {
-        targetIndex = info.currentIndex > 0 ? info.currentIndex - 1 : info.currentIndex
+        if info.currentIndex == 0 && wrapAround {
+          targetIndex = info.spaceCount - 1
+          shouldWrap = true
+        } else {
+          targetIndex = info.currentIndex > 0 ? info.currentIndex - 1 : info.currentIndex
+        }
       } else {
-        targetIndex =
-          info.currentIndex + 1 < info.spaceCount ? info.currentIndex + 1 : info.currentIndex
+        if info.currentIndex + 1 >= info.spaceCount && wrapAround {
+          targetIndex = 0
+          shouldWrap = true
+        } else {
+          targetIndex =
+            info.currentIndex + 1 < info.spaceCount ? info.currentIndex + 1 : info.currentIndex
+        }
       }
     }
 
-    if !iss_switch(direction) {
+    let success: Bool
+    if shouldWrap {
+      success = iss_switch_to_index(targetIndex)
+    } else {
+      success = iss_switch(direction)
+    }
+
+    if !success {
       NSSound.beep()
       return
     }

--- a/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
@@ -6,6 +6,8 @@ final class GeneralSettingsViewController: NSViewController {
     checkboxWithTitle: "Show on-screen display when switching spaces", target: nil, action: nil)
   private let osdDurationPopup = NSPopUpButton()
   private let osdDurationLabel = NSTextField(labelWithString: "Duration:")
+  private let wrapAroundCheckbox = NSButton(
+    checkboxWithTitle: "Wrap around when switching past left or rightmost space", target: nil, action: nil)
   private let launchAtLoginCheckbox = NSButton(
     checkboxWithTitle: "Launch at login", target: nil, action: nil)
 
@@ -49,12 +51,16 @@ final class GeneralSettingsViewController: NSViewController {
     osdDurationContainer.addArrangedSubview(osdDurationLabel)
     osdDurationContainer.addArrangedSubview(osdDurationPopup)
 
+    wrapAroundCheckbox.target = self
+    wrapAroundCheckbox.action = #selector(wrapAroundChanged)
+
     launchAtLoginCheckbox.target = self
     launchAtLoginCheckbox.action = #selector(launchAtLoginChanged)
 
     stackView.addArrangedSubview(generalLabel)
     stackView.addArrangedSubview(showOSDCheckbox)
     stackView.addArrangedSubview(osdDurationContainer)
+    stackView.addArrangedSubview(wrapAroundCheckbox)
     stackView.addArrangedSubview(launchAtLoginCheckbox)
 
     view.addSubview(stackView)
@@ -79,6 +85,8 @@ final class GeneralSettingsViewController: NSViewController {
 
     osdDurationPopup.isEnabled = showOSD
 
+    wrapAroundCheckbox.state = defaults.bool(forKey: "wrapAroundSpaces") ? .on : .off
+
     launchAtLoginCheckbox.state = SMAppService.mainApp.status == .enabled ? .on : .off
   }
 
@@ -86,6 +94,10 @@ final class GeneralSettingsViewController: NSViewController {
     let isEnabled = sender.state == .on
     defaults.set(isEnabled, forKey: "showOSD")
     osdDurationPopup.isEnabled = isEnabled
+  }
+
+  @objc private func wrapAroundChanged(_ sender: NSButton) {
+    defaults.set(sender.state == .on, forKey: "wrapAroundSpaces")
   }
 
   @objc private func osdDurationChanged(_ sender: NSPopUpButton) {


### PR DESCRIPTION
This PR adds a wrap-around mode for the switch right/switch left hotkeys. When enabled, switching left in the left-most space pushes the user to the right-most space, and vice versa. This way, one can access all spaces (eventually) with only switch left/right.

<img width="406" height="262" alt="Screenshot 2026-04-10 at 3 37 37 PM" src="https://github.com/user-attachments/assets/b9f19d69-1700-4cfc-8b9c-76ffb6e534d0" />


I "wrote" this PR with Claude Code, it is not human-generated (I reviewed its output. I am a software engineer). I don't expect this to actually get merged, nor do I mind if it is taken as inspiration; just figured I'd open a PR in case the maintainer(s) found it to be a good idea.
