### PR TITLE
add "Hide menu bar icon" setting

### DIFF
--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -57,6 +57,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     setupMainMenu()
     menuBarController.delegate = self
     menuBarController.setup()
+
+    if UserDefaults.standard.bool(forKey: "hideMenuBarIcon") {
+      menuBarController.setIconVisible(false)
+    }
+
     bindHotkeys()
     observeSpaceChanges()
     observeAppActivation()
@@ -226,6 +231,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           for: identifier, combination: self.hotkeyStore.combination(for: identifier))
       }
     }.store(in: &cancellables)
+  }
+
+  func setMenuBarIconVisible(_ visible: Bool) {
+    menuBarController.setIconVisible(visible)
   }
 
   func reregisterAllHotkeys() {

--- a/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
+++ b/Sources/InstantSpaceSwitcher/Core/MenuBarController.swift
@@ -217,6 +217,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     button.image = finalIcon
   }
 
+  func setIconVisible(_ visible: Bool) {
+    statusItem.isVisible = visible
+  }
+
   func applyHotkey(_ combination: HotkeyCombination, to identifier: HotkeyIdentifier) {
     let menuItem: NSMenuItem?
     switch identifier {

--- a/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/GeneralSettingsViewController.swift
@@ -17,6 +17,8 @@ final class GeneralSettingsViewController: NSViewController {
   private let animationSpeedLabel = NSTextField(labelWithString: "Animation Speed:")
   private let launchAtLoginCheckbox = NSButton(
     checkboxWithTitle: "Launch at login", target: nil, action: nil)
+  private let hideMenuBarIconCheckbox = NSButton(
+    checkboxWithTitle: "Hide menu bar icon", target: nil, action: nil)
 
   private let durationPresets = [100, 200, 300, 500, 750, 1000]
   private let animationSpeedOptions = ["Normal", "Fast", "Faster", "Fastest", "Instant"]
@@ -55,6 +57,8 @@ final class GeneralSettingsViewController: NSViewController {
     animationSpeedPopup.action = #selector(animationSpeedChanged)
     launchAtLoginCheckbox.target = self
     launchAtLoginCheckbox.action = #selector(launchAtLoginChanged)
+    hideMenuBarIconCheckbox.target = self
+    hideMenuBarIconCheckbox.action = #selector(hideMenuBarIconChanged)
 
     // Populate data
     for duration in durationPresets { osdDurationPopup.addItem(withTitle: "\(duration)ms") }
@@ -63,6 +67,7 @@ final class GeneralSettingsViewController: NSViewController {
     // System
     let systemLabel = NSTextField(labelWithString: "System:")
     formView.addRow(label: systemLabel, control: launchAtLoginCheckbox)
+    formView.addRow(label: nil, control: hideMenuBarIconCheckbox)
     formView.addRow(label: nil, control: swipeOverrideCheckbox)
 
     let experimentalTitle = NSMutableAttributedString(string: "Enable Mission Control/Exposé detection\n")
@@ -116,6 +121,7 @@ final class GeneralSettingsViewController: NSViewController {
     showOSDInMissionControlCheckbox.isEnabled = showOSD && overlayDetectionEnabled
     showOSDInMissionControlCheckbox.state = defaults.bool(forKey: "showOSDInMissionControl") ? .on : .off
 
+    hideMenuBarIconCheckbox.state = defaults.bool(forKey: "hideMenuBarIcon") ? .on : .off
     swipeOverrideCheckbox.state = defaults.bool(forKey: "swipeOverride") ? .on : .off
 
     let animationSpeedValue = defaults.double(forKey: "gestureSpeed")
@@ -178,6 +184,12 @@ final class GeneralSettingsViewController: NSViewController {
 
     defaults.set(velocity, forKey: "gestureSpeed")
     iss_set_gesture_speed(velocity)
+  }
+
+  @objc private func hideMenuBarIconChanged(_ sender: NSButton) {
+    let hide = sender.state == .on
+    defaults.set(hide, forKey: "hideMenuBarIcon")
+    (NSApp.delegate as? AppDelegate)?.setMenuBarIconVisible(!hide)
   }
 
   @objc private func launchAtLoginChanged(_ sender: NSButton) {


### PR DESCRIPTION
Some users prefer to run InstantSpaceSwitcher purely via hotkeys without a menu bar icon. This adds a "Hide menu bar icon" checkbox to the General settings tab.

When hidden, the status item is removed from the menu bar but the app continues to run normally: hotkeys and swipe override are unaffected. Settings can be reopened at any time by relaunching the app.