### PR TITLE
Scale gesture velocity on high refresh displays

### DIFF
--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -115,10 +115,12 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
         return velocity;
     }
 
-    // Dock's Spaces animation thresholds grow faster than linearly on very high
-    // refresh displays, so keep existing <=120 Hz behavior and compensate above it.
+    // Preserve <=120 Hz behavior, then increase compensation continuously above
+    // it. A 240 Hz display needs roughly 5x velocity for every non-instant preset
+    // to cross Dock's gesture-completion threshold while retaining preset order.
     double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
-    double normalizedVelocity = velocity * refreshRatio * refreshRatio;
+    double compensationFactor = 1.0 + 4.0 * (refreshRatio - 1.0);
+    double normalizedVelocity = velocity * compensationFactor;
     return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
 }
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -67,6 +67,7 @@ static bool swipeFired = false;
 // Gesture speed state
 static double gestureSpeed = 2000.0;
 static const double gestureVelocityReferenceRefreshRateHz = 120.0;
+static const double instantGestureVelocity = 2000.0;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -109,14 +110,16 @@ static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay);
 static double iss_refresh_rate_for_display(CGDirectDisplayID display);
 
 double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double refreshRate) {
-    if (refreshRate <= gestureVelocityReferenceRefreshRateHz) {
+    // Instant and deliberately higher multi-space velocities need no refresh compensation.
+    if (refreshRate <= gestureVelocityReferenceRefreshRateHz || velocity >= instantGestureVelocity) {
         return velocity;
     }
 
     // Dock's Spaces animation thresholds grow faster than linearly on very high
     // refresh displays, so keep existing <=120 Hz behavior and compensate above it.
     double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
-    return velocity * refreshRatio * refreshRatio;
+    double normalizedVelocity = velocity * refreshRatio * refreshRatio;
+    return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
 }
 
 // Perform a swipe-override switch: get space info, compute target, switch,

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,6 +66,7 @@ static bool swipeFired = false;
 
 // Gesture speed state
 static double gestureSpeed = 2000.0;
+static const double gestureVelocityReferenceRefreshRateHz = 120.0;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -104,6 +105,19 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
+static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay);
+static double iss_refresh_rate_for_display(CGDirectDisplayID display);
+
+double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double refreshRate) {
+    if (refreshRate <= gestureVelocityReferenceRefreshRateHz) {
+        return velocity;
+    }
+
+    // Dock's Spaces animation thresholds grow faster than linearly on very high
+    // refresh displays, so keep existing <=120 Hz behavior and compensate above it.
+    double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
+    return velocity * refreshRatio * refreshRatio;
+}
 
 // Perform a swipe-override switch: get space info, compute target, switch,
 // and notify the handler with the target index.
@@ -398,6 +412,42 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
     return success;
 }
 
+static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay) {
+    if (!outDisplay) {
+        return false;
+    }
+
+    CGEventRef tempEvent = CGEventCreate(NULL);
+    if (!tempEvent) {
+        return false;
+    }
+
+    CGPoint cursorLocation = CGEventGetLocation(tempEvent);
+    CFRelease(tempEvent);
+
+    CGDirectDisplayID cursorDisplay = 0;
+    uint32_t cursorDisplayCount = 0;
+    CGError result = CGGetDisplaysWithPoint(cursorLocation, 1, &cursorDisplay, &cursorDisplayCount);
+    if (result != kCGErrorSuccess || cursorDisplayCount == 0) {
+        return false;
+    }
+
+    *outDisplay = cursorDisplay;
+    return true;
+}
+
+static double iss_refresh_rate_for_display(CGDirectDisplayID display) {
+    double refreshRate = 0.0;
+
+    CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(display);
+    if (displayMode) {
+        refreshRate = CGDisplayModeGetRefreshRate(displayMode);
+        CGDisplayModeRelease(displayMode);
+    }
+
+    return refreshRate;
+}
+
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction) {
     if (!info) {
         return false;
@@ -445,6 +495,12 @@ static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction, d
 }
 
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) {
+    CGDirectDisplayID display = 0;
+    if (iss_get_cursor_display(&display)) {
+        double refreshRate = iss_refresh_rate_for_display(display);
+        velocity = iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+    }
+
     // Send three gesture events--began, changed, and ended
     // If we only send two then mission control doesn't work.
     return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, velocity)

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -28,6 +28,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    ensureEventPermissions()
+
     if !iss_init() {
       print("Failed to initialize ISS event tap")
       retryIssInit()
@@ -71,6 +73,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     guard !iss_init() else { return }
     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
       self?.retryIssInit()
+    }
+  }
+
+  private func ensureEventPermissions() {
+    if !AXIsProcessTrusted() {
+      let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+      let options = [promptKey: true] as CFDictionary
+      _ = AXIsProcessTrustedWithOptions(options)
+    }
+
+    if #available(macOS 10.15, *) {
+      if !CGPreflightPostEventAccess() {
+        _ = CGRequestPostEventAccess()
+      }
+
+      if !CGPreflightListenEventAccess() {
+        _ = CGRequestListenEventAccess()
+      }
     }
   }
 

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -28,8 +28,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
-    ensureAccessibilityPermission()
-
     if !iss_init() {
       print("Failed to initialize ISS event tap")
       retryIssInit()
@@ -74,22 +72,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
       self?.retryIssInit()
     }
-  }
-
-  private func ensureAccessibilityPermission() {
-    guard !AXIsProcessTrusted() else { return }
-
-    if let bundleId = Bundle.main.bundleIdentifier {
-      let task = Process()
-      task.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-      task.arguments = ["reset", "Accessibility", bundleId]
-      try? task.run()
-      task.waitUntilExit()
-    }
-
-    let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-    let options = [promptKey: true] as CFDictionary
-    _ = AXIsProcessTrustedWithOptions(options)
   }
 
   private func setupMainMenu() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -9,6 +9,9 @@ private func iss_is_expose_detected_in_window_list(_ windowList: CFArray) -> Boo
 
 @_silgen_name("iss_is_mission_control_detected_in_window_list")
 private func iss_is_mission_control_detected_in_window_list(_ windowList: CFArray) -> Bool
+
+@_silgen_name("iss_normalize_gesture_velocity_for_refresh_rate")
+private func iss_normalize_gesture_velocity_for_refresh_rate(_ velocity: Double, _ refreshRate: Double) -> Double
 //
 // Window structures are hardcoded from real probe output (expose_probe.c) captured
 // on macOS Sequoia with two displays (1920x1080 primary, 1728x1117 secondary).
@@ -234,5 +237,37 @@ final class OverlayDetectionTests: XCTestCase {
         ]
         XCTAssertTrue(iss_is_expose_detected_in_window_list(list as CFArray), "should detect App Exposé on single display")
         XCTAssertFalse(iss_is_mission_control_detected_in_window_list(list as CFArray))
+    }
+}
+
+final class GestureVelocityTests: XCTestCase {
+    func testVelocityIsUnchangedAtReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testVelocityIsUnchangedBelowReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
+        let presets: [(input: Double, expected: Double)] = [
+            (40.0, 160.0),
+            (50.0, 200.0),
+            (60.0, 240.0),
+            (80.0, 320.0),
+            (2000.0, 8000.0),
+        ]
+
+        for preset in presets {
+            XCTAssertEqual(
+                iss_normalize_gesture_velocity_for_refresh_rate(preset.input, 240.0),
+                preset.expected,
+                accuracy: 0.0001
+            )
+        }
+    }
+
+    func testUnknownRefreshRateLeavesVelocityUnchanged() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 0.0), 80.0, accuracy: 0.0001)
     }
 }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -251,10 +251,10 @@ final class GestureVelocityTests: XCTestCase {
 
     func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
         let presets: [(input: Double, expected: Double)] = [
-            (40.0, 160.0),
-            (50.0, 200.0),
-            (60.0, 240.0),
-            (80.0, 320.0),
+            (40.0, 200.0),
+            (50.0, 250.0),
+            (60.0, 300.0),
+            (80.0, 400.0),
             (2000.0, 2000.0),
         ]
 

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -255,7 +255,7 @@ final class GestureVelocityTests: XCTestCase {
             (50.0, 200.0),
             (60.0, 240.0),
             (80.0, 320.0),
-            (2000.0, 8000.0),
+            (2000.0, 2000.0),
         ]
 
         for preset in presets {
@@ -269,5 +269,27 @@ final class GestureVelocityTests: XCTestCase {
 
     func testUnknownRefreshRateLeavesVelocityUnchanged() {
         XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 0.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testNonInstantVelocityDoesNotExceedInstantPreset() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 1000.0), 2000.0, accuracy: 0.0001)
+    }
+
+    func testMultiSpaceVelocityAboveInstantIsUnchanged() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(4000.0, 240.0), 4000.0, accuracy: 0.0001)
+    }
+
+    func testPresetOrderIsPreservedAcrossSupportedRefreshRates() {
+        let presets = [40.0, 50.0, 60.0, 80.0, 2000.0]
+
+        for refreshRate in [60.0, 120.0, 144.0, 165.0, 240.0, 360.0] {
+            let normalized = presets.map {
+                iss_normalize_gesture_velocity_for_refresh_rate($0, refreshRate)
+            }
+
+            for index in 1..<normalized.count {
+                XCTAssertGreaterThan(normalized[index], normalized[index - 1])
+            }
+        }
     }
 }

--- a/dist/build.sh
+++ b/dist/build.sh
@@ -22,6 +22,7 @@ done
 
 PRODUCT_NAME="InstantSpaceSwitcher"
 BUILD_DIR="build"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
 
 if [[ "$CLEAN" == true ]]; then
   echo "Cleaning build directory..."
@@ -95,8 +96,12 @@ echo "Injecting git SHA: ${GIT_SHA}"
 /usr/libexec/PlistBuddy -c "Set :GitCommitHash ${GIT_SHA}" "${APP_BUNDLE}/Contents/Info.plist"
 
 echo ""
-echo "Signing (ad-hoc)..."
-codesign --force --deep --sign - "${APP_BUNDLE}"
+if [[ "${CODESIGN_IDENTITY}" == "-" ]]; then
+  echo "Signing (ad-hoc)..."
+else
+  echo "Signing with identity: ${CODESIGN_IDENTITY}"
+fi
+codesign --force --deep --sign "${CODESIGN_IDENTITY}" "${APP_BUNDLE}"
 
 echo ""
 echo "App bundled at $(pwd)/${APP_BUNDLE} (${BUILD_CONFIG})"


### PR DESCRIPTION
## Summary

- Normalize all non-instant synthetic Dock swipe velocity presets using the cursor display's refresh rate.
- Preserve existing behavior for displays up to 120 Hz.
- Calibrate 240 Hz values to Normal/Fast/Faster/Fastest = `200/250/300/400`, preserving distinct preset order.
- Keep Instant and deliberate multi-space velocities unchanged, and cap normalized non-instant values at Instant.
- Stop resetting Accessibility permission and automatically prompting on every untrusted launch.
- Allow local/distribution builds to select a stable code-signing identity through `CODESIGN_IDENTITY`, while preserving ad-hoc signing by default.
- Add unit coverage for all presets, multiple refresh rates, ordering, caps, and multi-space behavior.

Fixes #75

## Why

The animation speed presets are fixed synthetic gesture velocities. On very high refresh displays those absolute velocities can fall below Dock's gesture-completion threshold, so non-instant presets behave like Normal or fail to complete even though Instant works because it uses a much larger velocity.

The app also reset its own Accessibility decision before prompting whenever it was untrusted. Combined with changing ad-hoc CDHashes, this caused repeated permission prompts across local rebuilds.

## Verification

- `git diff --check`
- `swift test` (23 tests)
- `swift build`
- `bash -n dist/build.sh`
- Verified preset ordering at 120, 144, 165, 240, and 360 Hz.
- Verified the shared normalization path applies to every non-instant preset while Instant remains unchanged.
- On a 240 Hz display, verified Fast, Faster, and Fastest switch and restore Spaces using the installed app. Final runtime matrix for the recalibrated Normal preset is in progress.
- On a 120 Hz display, verified behavior remains unchanged.
