### PR TITLE
Normalize Dock gesture activation across displays

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),
                 .linkedFramework("CoreFoundation"),
+                .linkedFramework("CoreVideo"),
                 .linkedFramework("IOKit")
             ]
         ),

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -68,11 +68,11 @@ static bool swipeFired = false;
 static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double dockGestureActivationVelocityFloor = 80.0;
-static const double nonInstantGestureVelocitySpacingMultiplier = 3.0;
+static const double nonInstantGestureVelocityLinearMultiplier = 5.0;
+static const double nonInstantGestureVelocityQuadraticMultiplier = 0.1;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
-static const double gestureProgressVelocityDivisor = 480.0;
-static const double gestureMaximumProgress = 0.8;
+static const double nonInstantGestureProgress = 0.35;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -118,8 +118,8 @@ double iss_normalize_gesture_velocity(double velocity) {
     }
 
     // Dock has a shared non-instant completion threshold across displays. Move
-    // the non-instant range above that threshold, then widen preset spacing so
-    // Fast/Faster/Fastest remain visually distinct.
+    // the non-instant range above that threshold, then use a curved spacing so
+    // Fast/Faster/Fastest do not collapse into the same post-threshold band.
     double presetOffset = velocity - nonInstantGestureVelocityFloor;
     if (presetOffset < 0.0) {
         presetOffset = 0.0;
@@ -127,7 +127,8 @@ double iss_normalize_gesture_velocity(double velocity) {
 
     double normalizedVelocity =
         dockGestureActivationVelocityFloor +
-        presetOffset * nonInstantGestureVelocitySpacingMultiplier;
+        presetOffset * nonInstantGestureVelocityLinearMultiplier +
+        presetOffset * presetOffset * nonInstantGestureVelocityQuadraticMultiplier;
     return normalizedVelocity < instantGestureVelocity
         ? normalizedVelocity
         : nonInstantGestureVelocityCeiling;
@@ -143,12 +144,7 @@ double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
         return (double)FLT_TRUE_MIN;
     }
 
-    double progress = velocity / gestureProgressVelocityDivisor;
-    if (progress > gestureMaximumProgress) {
-        return gestureMaximumProgress;
-    }
-
-    return progress > (double)FLT_TRUE_MIN ? progress : (double)FLT_TRUE_MIN;
+    return nonInstantGestureProgress;
 }
 
 // Perform a swipe-override switch: get space info, compute target, switch,

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -67,6 +67,7 @@ static bool swipeFired = false;
 // Gesture speed state
 static double gestureSpeed = 2000.0;
 static const double gestureVelocityReferenceRefreshRateHz = 120.0;
+static const double nonInstantGestureVelocityFloor = 40.0;
 static const double instantGestureVelocity = 2000.0;
 
 static ISSSwitchCallback switchCallback = NULL;
@@ -115,12 +116,20 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
         return velocity;
     }
 
-    // Preserve <=120 Hz behavior, then increase compensation continuously above
-    // it. A 240 Hz display needs roughly 5x velocity for every non-instant preset
-    // to cross Dock's gesture-completion threshold while retaining preset order.
+    // Preserve <=120 Hz behavior, then add the high-refresh completion floor
+    // separately from the preset spacing. This keeps non-instant presets
+    // perceptually distinct instead of multiplying the whole scale into the
+    // same near-instant range.
     double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
-    double compensationFactor = 1.0 + 4.0 * (refreshRatio - 1.0);
-    double normalizedVelocity = velocity * compensationFactor;
+    double refreshDelta = refreshRatio - 1.0;
+    double completionFloor = nonInstantGestureVelocityFloor + 160.0 * refreshDelta;
+    double presetSlope = 1.0 + 1.5 * refreshDelta;
+    double presetOffset = velocity - nonInstantGestureVelocityFloor;
+    if (presetOffset < 0.0) {
+        presetOffset = 0.0;
+    }
+
+    double normalizedVelocity = completionFloor + presetOffset * presetSlope;
     return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
 }
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -120,6 +120,20 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
     return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
 }
 
+double iss_dock_swipe_velocity_for_phase(double velocity, double refreshRate, int phase) {
+    double normalizedVelocity = iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+
+    // Dock uses the final phase as the commit impulse. Keep animation phases tuned
+    // by refresh rate, but end with an instant-strength velocity so low-speed
+    // presets do not wait before the Space transition is committed.
+    if (phase == kCGSGesturePhaseEnded && normalizedVelocity > 0.0 &&
+        normalizedVelocity < instantGestureVelocity) {
+        return instantGestureVelocity;
+    }
+
+    return normalizedVelocity;
+}
+
 // Perform a swipe-override switch: get space info, compute target, switch,
 // and notify the handler with the target index.
 static void swipe_override_switch(ISSDirection dir) {
@@ -473,7 +487,7 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction) {
 
 static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction, double velocity) {
     const bool isRight = (direction == ISSDirectionRight);
-    // Empirically, ±FLT_TRUE_MIN used in this way makes switching instant.
+    // Keep progress near zero; velocity controls animation speed and final commit.
     const double progress = isRight ? (double)FLT_TRUE_MIN : -(double)FLT_TRUE_MIN;
 
     // Velocity of gesture based on speed setting
@@ -496,17 +510,21 @@ static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction, d
 }
 
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) {
+    double refreshRate = 0.0;
     CGDirectDisplayID display = 0;
     if (iss_get_cursor_display(&display)) {
-        double refreshRate = iss_refresh_rate_for_display(display);
-        velocity = iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+        refreshRate = iss_refresh_rate_for_display(display);
     }
+
+    double beganVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseBegan);
+    double changedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseChanged);
+    double endedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseEnded);
 
     // Send three gesture events--began, changed, and ended
     // If we only send two then mission control doesn't work.
-    return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, velocity)
-        && iss_post_dock_swipe(kCGSGesturePhaseChanged, direction, velocity)
-        && iss_post_dock_swipe(kCGSGesturePhaseEnded,   direction, velocity);
+    return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, beganVelocity)
+        && iss_post_dock_swipe(kCGSGesturePhaseChanged, direction, changedVelocity)
+        && iss_post_dock_swipe(kCGSGesturePhaseEnded,   direction, endedVelocity);
 }
 
 /** @brief Walks a CGWindowListCopyWindowInfo result

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,8 +66,10 @@ static bool swipeFired = false;
 
 // Gesture speed state
 static double gestureSpeed = 2000.0;
-static const double gestureVelocityReferenceRefreshRateHz = 120.0;
+static const double nonInstantGestureVelocityFloor = 40.0;
+static const double dockGestureActivationVelocityFloor = 80.0;
 static const double instantGestureVelocity = 2000.0;
+static const double nonInstantGestureVelocityCeiling = 1999.0;
 static const double gestureProgressVelocityDivisor = 480.0;
 static const double gestureMaximumProgress = 0.8;
 
@@ -108,23 +110,28 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
-static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay);
-static double iss_refresh_rate_for_display(CGDirectDisplayID display);
 
-double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double refreshRate) {
-    // Instant and deliberately higher multi-space velocities need no refresh compensation.
-    if (refreshRate <= 0.0 || velocity >= instantGestureVelocity) {
+double iss_normalize_gesture_velocity(double velocity) {
+    if (velocity <= 0.0 || velocity >= instantGestureVelocity) {
         return velocity;
     }
 
-    double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
-    double normalizedVelocity = velocity * refreshRatio;
-    return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
+    // Dock has a shared non-instant completion threshold across displays. Keep
+    // preset spacing, but move the whole non-instant range above that threshold.
+    double presetOffset = velocity - nonInstantGestureVelocityFloor;
+    if (presetOffset < 0.0) {
+        presetOffset = 0.0;
+    }
+
+    double normalizedVelocity = dockGestureActivationVelocityFloor + presetOffset;
+    return normalizedVelocity < instantGestureVelocity
+        ? normalizedVelocity
+        : nonInstantGestureVelocityCeiling;
 }
 
-double iss_dock_swipe_velocity_for_phase(double velocity, double refreshRate, int phase) {
+double iss_dock_swipe_velocity_for_phase(double velocity, int phase) {
     (void)phase;
-    return iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+    return iss_normalize_gesture_velocity(velocity);
 }
 
 double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
@@ -433,42 +440,6 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
     return success;
 }
 
-static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay) {
-    if (!outDisplay) {
-        return false;
-    }
-
-    CGEventRef tempEvent = CGEventCreate(NULL);
-    if (!tempEvent) {
-        return false;
-    }
-
-    CGPoint cursorLocation = CGEventGetLocation(tempEvent);
-    CFRelease(tempEvent);
-
-    CGDirectDisplayID cursorDisplay = 0;
-    uint32_t cursorDisplayCount = 0;
-    CGError result = CGGetDisplaysWithPoint(cursorLocation, 1, &cursorDisplay, &cursorDisplayCount);
-    if (result != kCGErrorSuccess || cursorDisplayCount == 0) {
-        return false;
-    }
-
-    *outDisplay = cursorDisplay;
-    return true;
-}
-
-static double iss_refresh_rate_for_display(CGDirectDisplayID display) {
-    double refreshRate = 0.0;
-
-    CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(display);
-    if (displayMode) {
-        refreshRate = CGDisplayModeGetRefreshRate(displayMode);
-        CGDisplayModeRelease(displayMode);
-    }
-
-    return refreshRate;
-}
-
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction) {
     if (!info) {
         return false;
@@ -518,15 +489,9 @@ static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction,
 }
 
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) {
-    double refreshRate = 0.0;
-    CGDirectDisplayID display = 0;
-    if (iss_get_cursor_display(&display)) {
-        refreshRate = iss_refresh_rate_for_display(display);
-    }
-
-    double beganVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseBegan);
-    double changedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseChanged);
-    double endedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseEnded);
+    double beganVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseBegan);
+    double changedVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseChanged);
+    double endedVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseEnded);
     double beganProgress = iss_dock_swipe_progress_for_phase(beganVelocity, kCGSGesturePhaseBegan);
     double changedProgress = iss_dock_swipe_progress_for_phase(changedVelocity, kCGSGesturePhaseChanged);
     double endedProgress = iss_dock_swipe_progress_for_phase(endedVelocity, kCGSGesturePhaseEnded);

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -112,15 +112,19 @@ static double iss_refresh_rate_for_display(CGDirectDisplayID display);
 
 double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double refreshRate) {
     // Instant and deliberately higher multi-space velocities need no refresh compensation.
-    if (refreshRate <= gestureVelocityReferenceRefreshRateHz || velocity >= instantGestureVelocity) {
+    if (refreshRate <= 0.0 || velocity >= instantGestureVelocity) {
         return velocity;
     }
 
-    // Preserve <=120 Hz behavior, then add the high-refresh completion floor
+    double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
+    if (refreshRate <= gestureVelocityReferenceRefreshRateHz) {
+        return velocity * refreshRatio;
+    }
+
+    // Preserve the 120 Hz baseline, then add the high-refresh completion floor
     // separately from the preset spacing. This keeps non-instant presets
     // perceptually distinct instead of multiplying the whole scale into the
     // same near-instant range.
-    double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
     double refreshDelta = refreshRatio - 1.0;
     double completionFloor = nonInstantGestureVelocityFloor + 160.0 * refreshDelta;
     double presetSlope = 1.0 + 1.5 * refreshDelta;

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -68,6 +68,7 @@ static bool swipeFired = false;
 static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double dockGestureActivationVelocityFloor = 80.0;
+static const double nonInstantGestureVelocitySpacingMultiplier = 3.0;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
 static const double gestureProgressVelocityDivisor = 480.0;
@@ -116,14 +117,17 @@ double iss_normalize_gesture_velocity(double velocity) {
         return velocity;
     }
 
-    // Dock has a shared non-instant completion threshold across displays. Keep
-    // preset spacing, but move the whole non-instant range above that threshold.
+    // Dock has a shared non-instant completion threshold across displays. Move
+    // the non-instant range above that threshold, then widen preset spacing so
+    // Fast/Faster/Fastest remain visually distinct.
     double presetOffset = velocity - nonInstantGestureVelocityFloor;
     if (presetOffset < 0.0) {
         presetOffset = 0.0;
     }
 
-    double normalizedVelocity = dockGestureActivationVelocityFloor + presetOffset;
+    double normalizedVelocity =
+        dockGestureActivationVelocityFloor +
+        presetOffset * nonInstantGestureVelocitySpacingMultiplier;
     return normalizedVelocity < instantGestureVelocity
         ? normalizedVelocity
         : nonInstantGestureVelocityCeiling;

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -67,12 +67,11 @@ static bool swipeFired = false;
 // Gesture speed state
 static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
-static const double dockGestureActivationVelocityFloor = 70.0;
-static const double nonInstantGestureVelocityLinearMultiplier = 0.9;
-static const double nonInstantGestureVelocityQuadraticMultiplier = 0.035;
+static const double nonInstantGestureVelocityLinearMultiplier = 0.45;
+static const double nonInstantGestureVelocityQuadraticMultiplier = 0.0175;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
-static const double nonInstantGestureProgress = 0.18;
+static const double nonInstantGestureProgress = 0.09;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -117,16 +116,16 @@ double iss_normalize_gesture_velocity(double velocity) {
         return velocity;
     }
 
-    // Dock has a shared non-instant completion threshold across displays. Move
-    // the non-instant range above that threshold, then use a curved spacing so
-    // Fast/Faster/Fastest do not collapse into the same post-threshold band.
+    // Keep Normal at the original raw gesture velocity, then use a shallow
+    // curved spacing so faster presets stay distinct without entering Dock's
+    // overly aggressive completion band.
     double presetOffset = velocity - nonInstantGestureVelocityFloor;
     if (presetOffset < 0.0) {
         presetOffset = 0.0;
     }
 
     double normalizedVelocity =
-        dockGestureActivationVelocityFloor +
+        nonInstantGestureVelocityFloor +
         presetOffset * nonInstantGestureVelocityLinearMultiplier +
         presetOffset * presetOffset * nonInstantGestureVelocityQuadraticMultiplier;
     return normalizedVelocity < instantGestureVelocity
@@ -140,7 +139,9 @@ double iss_dock_swipe_velocity_for_phase(double velocity, int phase) {
 }
 
 double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
-    if (phase == kCGSGesturePhaseBegan || velocity <= 0.0 || velocity >= instantGestureVelocity) {
+    if (phase == kCGSGesturePhaseBegan
+        || velocity <= nonInstantGestureVelocityFloor
+        || velocity >= instantGestureVelocity) {
         return (double)FLT_TRUE_MIN;
     }
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -68,6 +68,8 @@ static bool swipeFired = false;
 static double gestureSpeed = 2000.0;
 static const double gestureVelocityReferenceRefreshRateHz = 120.0;
 static const double instantGestureVelocity = 2000.0;
+static const double gestureProgressVelocityDivisor = 480.0;
+static const double gestureMaximumProgress = 0.8;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -121,17 +123,21 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
 }
 
 double iss_dock_swipe_velocity_for_phase(double velocity, double refreshRate, int phase) {
-    double normalizedVelocity = iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+    (void)phase;
+    return iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+}
 
-    // Dock uses the final phase as the commit impulse. Keep animation phases tuned
-    // by refresh rate, but end with an instant-strength velocity so low-speed
-    // presets do not wait before the Space transition is committed.
-    if (phase == kCGSGesturePhaseEnded && normalizedVelocity > 0.0 &&
-        normalizedVelocity < instantGestureVelocity) {
-        return instantGestureVelocity;
+double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
+    if (phase == kCGSGesturePhaseBegan || velocity <= 0.0 || velocity >= instantGestureVelocity) {
+        return (double)FLT_TRUE_MIN;
     }
 
-    return normalizedVelocity;
+    double progress = velocity / gestureProgressVelocityDivisor;
+    if (progress > gestureMaximumProgress) {
+        return gestureMaximumProgress;
+    }
+
+    return progress > (double)FLT_TRUE_MIN ? progress : (double)FLT_TRUE_MIN;
 }
 
 // Perform a swipe-override switch: get space info, compute target, switch,
@@ -485,10 +491,12 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction) {
     return !iss_should_block_switch(&info, direction);
 }
 
-static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction, double velocity) {
+static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction,
+                                double velocity, double progressMagnitude) {
     const bool isRight = (direction == ISSDirectionRight);
-    // Keep progress near zero; velocity controls animation speed and final commit.
-    const double progress = isRight ? (double)FLT_TRUE_MIN : -(double)FLT_TRUE_MIN;
+    // Velocity controls animation speed; progress gives Dock enough swipe distance
+    // to commit non-instant gestures without upgrading them to Instant velocity.
+    const double progress = isRight ? progressMagnitude : -progressMagnitude;
 
     // Velocity of gesture based on speed setting
     const double vel = isRight ? velocity : -velocity;
@@ -519,12 +527,15 @@ static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) 
     double beganVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseBegan);
     double changedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseChanged);
     double endedVelocity = iss_dock_swipe_velocity_for_phase(velocity, refreshRate, kCGSGesturePhaseEnded);
+    double beganProgress = iss_dock_swipe_progress_for_phase(beganVelocity, kCGSGesturePhaseBegan);
+    double changedProgress = iss_dock_swipe_progress_for_phase(changedVelocity, kCGSGesturePhaseChanged);
+    double endedProgress = iss_dock_swipe_progress_for_phase(endedVelocity, kCGSGesturePhaseEnded);
 
     // Send three gesture events--began, changed, and ended
     // If we only send two then mission control doesn't work.
-    return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, beganVelocity)
-        && iss_post_dock_swipe(kCGSGesturePhaseChanged, direction, changedVelocity)
-        && iss_post_dock_swipe(kCGSGesturePhaseEnded,   direction, endedVelocity);
+    return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, beganVelocity,   beganProgress)
+        && iss_post_dock_swipe(kCGSGesturePhaseChanged, direction, changedVelocity, changedProgress)
+        && iss_post_dock_swipe(kCGSGesturePhaseEnded,   direction, endedVelocity,   endedProgress);
 }
 
 /** @brief Walks a CGWindowListCopyWindowInfo result

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,9 +66,7 @@ static bool swipeFired = false;
 
 // Gesture speed state
 static double gestureSpeed = 2000.0;
-static const double gestureVelocityLowRefreshReferenceHz = 60.0;
 static const double gestureVelocityReferenceRefreshRateHz = 120.0;
-static const double nonInstantGestureVelocityFloor = 40.0;
 static const double instantGestureVelocity = 2000.0;
 
 static ISSSwitchCallback switchCallback = NULL;
@@ -118,24 +116,7 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
     }
 
     double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
-    if (refreshRate <= gestureVelocityReferenceRefreshRateHz) {
-        return velocity * (refreshRate / gestureVelocityLowRefreshReferenceHz);
-    }
-
-    // Use 60 Hz as the lower reference and 120 Hz as the pivot, then add the
-    // high-refresh completion floor separately from the preset spacing. This
-    // makes 120 Hz and 240 Hz perceived speed line up without multiplying all
-    // high-refresh presets into the same near-instant range.
-    double refreshDelta = refreshRatio - 1.0;
-    double lowRefreshScale = gestureVelocityReferenceRefreshRateHz / gestureVelocityLowRefreshReferenceHz;
-    double completionFloor = nonInstantGestureVelocityFloor * lowRefreshScale + 120.0 * refreshDelta;
-    double presetSlope = lowRefreshScale + 0.5 * refreshDelta;
-    double presetOffset = velocity - nonInstantGestureVelocityFloor;
-    if (presetOffset < 0.0) {
-        presetOffset = 0.0;
-    }
-
-    double normalizedVelocity = completionFloor + presetOffset * presetSlope;
+    double normalizedVelocity = velocity * refreshRatio;
     return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
 }
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,6 +66,8 @@ static bool swipeFired = false;
 
 // Gesture speed state
 static double gestureSpeed = 2000.0;
+static const double gestureVelocityReferenceRefreshRateHz = 120.0;
+static const double instantGestureVelocity = 2000.0;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -104,6 +106,23 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
+static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay);
+static double iss_refresh_rate_for_display(CGDirectDisplayID display);
+
+double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double refreshRate) {
+    // Instant and deliberately higher multi-space velocities need no refresh compensation.
+    if (refreshRate <= gestureVelocityReferenceRefreshRateHz || velocity >= instantGestureVelocity) {
+        return velocity;
+    }
+
+    // Preserve <=120 Hz behavior, then increase compensation continuously above
+    // it. A 240 Hz display needs roughly 5x velocity for every non-instant preset
+    // to cross Dock's gesture-completion threshold while retaining preset order.
+    double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
+    double compensationFactor = 1.0 + 4.0 * (refreshRatio - 1.0);
+    double normalizedVelocity = velocity * compensationFactor;
+    return normalizedVelocity < instantGestureVelocity ? normalizedVelocity : instantGestureVelocity;
+}
 
 // Perform a swipe-override switch: get space info, compute target, switch,
 // and notify the handler with the target index.
@@ -398,6 +417,42 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
     return success;
 }
 
+static bool iss_get_cursor_display(CGDirectDisplayID *outDisplay) {
+    if (!outDisplay) {
+        return false;
+    }
+
+    CGEventRef tempEvent = CGEventCreate(NULL);
+    if (!tempEvent) {
+        return false;
+    }
+
+    CGPoint cursorLocation = CGEventGetLocation(tempEvent);
+    CFRelease(tempEvent);
+
+    CGDirectDisplayID cursorDisplay = 0;
+    uint32_t cursorDisplayCount = 0;
+    CGError result = CGGetDisplaysWithPoint(cursorLocation, 1, &cursorDisplay, &cursorDisplayCount);
+    if (result != kCGErrorSuccess || cursorDisplayCount == 0) {
+        return false;
+    }
+
+    *outDisplay = cursorDisplay;
+    return true;
+}
+
+static double iss_refresh_rate_for_display(CGDirectDisplayID display) {
+    double refreshRate = 0.0;
+
+    CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(display);
+    if (displayMode) {
+        refreshRate = CGDisplayModeGetRefreshRate(displayMode);
+        CGDisplayModeRelease(displayMode);
+    }
+
+    return refreshRate;
+}
+
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction) {
     if (!info) {
         return false;
@@ -445,6 +500,12 @@ static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction, d
 }
 
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) {
+    CGDirectDisplayID display = 0;
+    if (iss_get_cursor_display(&display)) {
+        double refreshRate = iss_refresh_rate_for_display(display);
+        velocity = iss_normalize_gesture_velocity_for_refresh_rate(velocity, refreshRate);
+    }
+
     // Send three gesture events--began, changed, and ended
     // If we only send two then mission control doesn't work.
     return iss_post_dock_swipe(kCGSGesturePhaseBegan,   direction, velocity)

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -66,6 +66,7 @@ static bool swipeFired = false;
 
 // Gesture speed state
 static double gestureSpeed = 2000.0;
+static const double gestureVelocityLowRefreshReferenceHz = 60.0;
 static const double gestureVelocityReferenceRefreshRateHz = 120.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double instantGestureVelocity = 2000.0;
@@ -118,16 +119,17 @@ double iss_normalize_gesture_velocity_for_refresh_rate(double velocity, double r
 
     double refreshRatio = refreshRate / gestureVelocityReferenceRefreshRateHz;
     if (refreshRate <= gestureVelocityReferenceRefreshRateHz) {
-        return velocity * refreshRatio;
+        return velocity * (refreshRate / gestureVelocityLowRefreshReferenceHz);
     }
 
-    // Preserve the 120 Hz baseline, then add the high-refresh completion floor
-    // separately from the preset spacing. This keeps non-instant presets
-    // perceptually distinct instead of multiplying the whole scale into the
-    // same near-instant range.
+    // Use 60 Hz as the lower reference and 120 Hz as the pivot, then add the
+    // high-refresh completion floor separately from the preset spacing. This
+    // makes 120 Hz and 240 Hz perceived speed line up without multiplying all
+    // high-refresh presets into the same near-instant range.
     double refreshDelta = refreshRatio - 1.0;
-    double completionFloor = nonInstantGestureVelocityFloor + 160.0 * refreshDelta;
-    double presetSlope = 1.0 + 1.5 * refreshDelta;
+    double lowRefreshScale = gestureVelocityReferenceRefreshRateHz / gestureVelocityLowRefreshReferenceHz;
+    double completionFloor = nonInstantGestureVelocityFloor * lowRefreshScale + 120.0 * refreshDelta;
+    double presetSlope = lowRefreshScale + 0.5 * refreshDelta;
     double presetOffset = velocity - nonInstantGestureVelocityFloor;
     if (presetOffset < 0.0) {
         presetOffset = 0.0;

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -3,6 +3,7 @@
 #include <ApplicationServices/ApplicationServices.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CGEventTypes.h>
+#include <CoreVideo/CoreVideo.h>
 #include <assert.h>
 #include <dlfcn.h>
 #include <float.h>
@@ -107,11 +108,11 @@ static bool extract_space_info_from_display(CFDictionaryRef displayDict,
                                             bool hasActiveSpace,
                                             ISSSpaceInfo *outInfo);
 static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDisplay);
-static bool iss_perform_switch_gesture(ISSDirection direction, double velocity);
+static bool iss_perform_switch_gesture(ISSDirection direction, double velocity, const char *displayID);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
 
-double iss_normalize_gesture_velocity(double velocity) {
+static double iss_base_gesture_velocity(double velocity) {
     if (velocity <= 0.0 || velocity >= instantGestureVelocity) {
         return velocity;
     }
@@ -133,12 +134,60 @@ double iss_normalize_gesture_velocity(double velocity) {
         : nonInstantGestureVelocityCeiling;
 }
 
+double iss_refresh_rate_normalization_scale(double displayRefreshRate, double baselineRefreshRate) {
+    if (displayRefreshRate <= 0.0 || baselineRefreshRate <= 0.0) {
+        return 1.0;
+    }
+
+    return displayRefreshRate / baselineRefreshRate;
+}
+
+double iss_normalize_gesture_velocity_for_refresh_rate(double velocity,
+                                                       double displayRefreshRate,
+                                                       double baselineRefreshRate) {
+    double normalizedVelocity = iss_base_gesture_velocity(velocity);
+    if (velocity <= 0.0 || velocity >= instantGestureVelocity) {
+        return normalizedVelocity;
+    }
+
+    if (normalizedVelocity <= nonInstantGestureVelocityFloor) {
+        return normalizedVelocity;
+    }
+
+    double scaledOffset =
+        (normalizedVelocity - nonInstantGestureVelocityFloor)
+        * iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
+    normalizedVelocity = nonInstantGestureVelocityFloor + scaledOffset;
+    return normalizedVelocity < instantGestureVelocity
+        ? normalizedVelocity
+        : nonInstantGestureVelocityCeiling;
+}
+
+double iss_normalize_gesture_velocity(double velocity) {
+    return iss_normalize_gesture_velocity_for_refresh_rate(velocity, 0.0, 0.0);
+}
+
 double iss_dock_swipe_velocity_for_phase(double velocity, int phase) {
     (void)phase;
     return iss_normalize_gesture_velocity(velocity);
 }
 
-double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
+double iss_dock_swipe_velocity_for_phase_and_refresh_rate(double velocity,
+                                                          int phase,
+                                                          double displayRefreshRate,
+                                                          double baselineRefreshRate) {
+    (void)phase;
+    return iss_normalize_gesture_velocity_for_refresh_rate(
+        velocity,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+}
+
+double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
+                                                          int phase,
+                                                          double displayRefreshRate,
+                                                          double baselineRefreshRate) {
     if (phase == kCGSGesturePhaseBegan
         || velocity <= nonInstantGestureVelocityFloor
         || velocity >= instantGestureVelocity) {
@@ -148,12 +197,16 @@ double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
     return nonInstantGestureProgress;
 }
 
+double iss_dock_swipe_progress_for_phase(double velocity, int phase) {
+    return iss_dock_swipe_progress_for_phase_and_refresh_rate(velocity, phase, 0.0, 0.0);
+}
+
 // Perform a swipe-override switch: get space info, compute target, switch,
 // and notify the handler with the target index.
 static void swipe_override_switch(ISSDirection dir) {
     ISSSpaceInfo info;
     if (!iss_get_space_info(&info)) {
-        iss_perform_switch_gesture(dir, gestureSpeed);
+        iss_perform_switch_gesture(dir, gestureSpeed, NULL);
         return;
     }
 
@@ -463,6 +516,114 @@ bool iss_can_move(ISSSpaceInfo info, ISSDirection direction) {
     return !iss_should_block_switch(&info, direction);
 }
 
+static bool iss_copy_display_uuid_string(CGDirectDisplayID displayID, char *buffer, size_t bufferSize) {
+    if (!buffer || bufferSize == 0) {
+        return false;
+    }
+
+    buffer[0] = '\0';
+    CFUUIDRef uuid = CGDisplayCreateUUIDFromDisplayID(displayID);
+    if (!uuid) {
+        return false;
+    }
+
+    CFStringRef uuidString = CFUUIDCreateString(NULL, uuid);
+    CFRelease(uuid);
+    if (!uuidString) {
+        return false;
+    }
+
+    bool success = CFStringGetCString(uuidString, buffer, bufferSize, kCFStringEncodingUTF8);
+    CFRelease(uuidString);
+    return success;
+}
+
+static double iss_refresh_rate_for_display(CGDirectDisplayID displayID) {
+    double refreshRate = 0.0;
+
+    CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayID);
+    if (mode) {
+        refreshRate = CGDisplayModeGetRefreshRate(mode);
+        CGDisplayModeRelease(mode);
+    }
+    if (refreshRate > 0.0) {
+        return refreshRate;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CVDisplayLinkRef displayLink = NULL;
+    if (CVDisplayLinkCreateWithCGDisplay(displayID, &displayLink) == kCVReturnSuccess && displayLink) {
+        CVTime nominalPeriod = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
+        if (nominalPeriod.timeValue > 0 && nominalPeriod.timeScale > 0) {
+            refreshRate = (double)nominalPeriod.timeScale / (double)nominalPeriod.timeValue;
+        }
+        CVDisplayLinkRelease(displayLink);
+    }
+#pragma clang diagnostic pop
+
+    return refreshRate;
+}
+
+static double iss_min_active_display_refresh_rate(void) {
+    uint32_t displayCount = 0;
+    if (CGGetActiveDisplayList(0, NULL, &displayCount) != kCGErrorSuccess || displayCount == 0) {
+        return 0.0;
+    }
+
+    CGDirectDisplayID displays[32] = {0};
+    if (displayCount > 32) {
+        displayCount = 32;
+    }
+    if (CGGetActiveDisplayList(displayCount, displays, &displayCount) != kCGErrorSuccess) {
+        return 0.0;
+    }
+
+    double minRefreshRate = 0.0;
+    for (uint32_t i = 0; i < displayCount; i++) {
+        double refreshRate = iss_refresh_rate_for_display(displays[i]);
+        if (refreshRate <= 0.0) {
+            continue;
+        }
+        if (minRefreshRate <= 0.0 || refreshRate < minRefreshRate) {
+            minRefreshRate = refreshRate;
+        }
+    }
+
+    return minRefreshRate;
+}
+
+static double iss_refresh_rate_for_display_identifier(const char *displayIdentifier) {
+    if (!displayIdentifier || displayIdentifier[0] == '\0') {
+        return 0.0;
+    }
+
+    uint32_t displayCount = 0;
+    if (CGGetActiveDisplayList(0, NULL, &displayCount) != kCGErrorSuccess || displayCount == 0) {
+        return 0.0;
+    }
+
+    CGDirectDisplayID displays[32] = {0};
+    if (displayCount > 32) {
+        displayCount = 32;
+    }
+    if (CGGetActiveDisplayList(displayCount, displays, &displayCount) != kCGErrorSuccess) {
+        return 0.0;
+    }
+
+    for (uint32_t i = 0; i < displayCount; i++) {
+        char uuidString[128] = {0};
+        if (!iss_copy_display_uuid_string(displays[i], uuidString, sizeof(uuidString))) {
+            continue;
+        }
+        if (strcmp(uuidString, displayIdentifier) == 0) {
+            return iss_refresh_rate_for_display(displays[i]);
+        }
+    }
+
+    return 0.0;
+}
+
 static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction,
                                 double velocity, double progressMagnitude) {
     const bool isRight = (direction == ISSDirectionRight);
@@ -489,13 +650,46 @@ static bool iss_post_dock_swipe(CGSGesturePhase phase, ISSDirection direction,
     return true;
 }
 
-static bool iss_perform_switch_gesture(ISSDirection direction, double velocity) {
-    double beganVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseBegan);
-    double changedVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseChanged);
-    double endedVelocity = iss_dock_swipe_velocity_for_phase(velocity, kCGSGesturePhaseEnded);
-    double beganProgress = iss_dock_swipe_progress_for_phase(beganVelocity, kCGSGesturePhaseBegan);
-    double changedProgress = iss_dock_swipe_progress_for_phase(changedVelocity, kCGSGesturePhaseChanged);
-    double endedProgress = iss_dock_swipe_progress_for_phase(endedVelocity, kCGSGesturePhaseEnded);
+static bool iss_perform_switch_gesture(ISSDirection direction, double velocity, const char *displayID) {
+    double displayRefreshRate = iss_refresh_rate_for_display_identifier(displayID);
+    double baselineRefreshRate = iss_min_active_display_refresh_rate();
+
+    double beganVelocity = iss_dock_swipe_velocity_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseBegan,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+    double changedVelocity = iss_dock_swipe_velocity_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseChanged,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+    double endedVelocity = iss_dock_swipe_velocity_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseEnded,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+    double beganProgress = iss_dock_swipe_progress_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseBegan,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+    double changedProgress = iss_dock_swipe_progress_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseChanged,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
+    double endedProgress = iss_dock_swipe_progress_for_phase_and_refresh_rate(
+        velocity,
+        kCGSGesturePhaseEnded,
+        displayRefreshRate,
+        baselineRefreshRate
+    );
 
     // Send three gesture events--began, changed, and ended
     // If we only send two then mission control doesn't work.
@@ -652,7 +846,7 @@ static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection directio
     if (iss_should_block_switch(info, direction)) {
         return false;
     }
-    if (!iss_perform_switch_gesture(direction, gestureSpeed)) {
+    if (!iss_perform_switch_gesture(direction, gestureSpeed, info ? info->displayID : NULL)) {
         return false;
     }
 
@@ -674,7 +868,7 @@ bool iss_switch(ISSDirection direction) {
         return true;
     }
 
-    return iss_perform_switch_gesture(direction, gestureSpeed);
+    return iss_perform_switch_gesture(direction, gestureSpeed, NULL);
 }
 
 bool iss_switch_to_index(unsigned int targetIndex) {
@@ -704,7 +898,7 @@ bool iss_switch_to_index(unsigned int targetIndex) {
     double velocity = gestureSpeed * steps;
 
     for (unsigned int i = 0; i < steps; i++) {
-        if (!iss_perform_switch_gesture(direction, velocity)) {
+        if (!iss_perform_switch_gesture(direction, velocity, info.displayID)) {
             return false;
         }
     }

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -195,9 +195,11 @@ double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
         return (double)FLT_TRUE_MIN;
     }
 
-    double progress =
-        nonInstantGestureProgress
-        * iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
+    double progress = nonInstantGestureProgress;
+    if (phase == kCGSGesturePhaseEnded) {
+        double refreshScale = iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
+        progress *= refreshScale * refreshScale;
+    }
     return progress < nonInstantGestureProgressCeiling
         ? progress
         : nonInstantGestureProgressCeiling;

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -73,6 +73,7 @@ static const double nonInstantGestureVelocityQuadraticMultiplier = 0.0175;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
 static const double nonInstantGestureProgress = 0.09;
+static const double nonInstantGestureProgressCeiling = 0.35;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -194,7 +195,12 @@ double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
         return (double)FLT_TRUE_MIN;
     }
 
-    return nonInstantGestureProgress;
+    double progress =
+        nonInstantGestureProgress
+        * iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
+    return progress < nonInstantGestureProgressCeiling
+        ? progress
+        : nonInstantGestureProgressCeiling;
 }
 
 double iss_dock_swipe_progress_for_phase(double velocity, int phase) {

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -68,11 +68,11 @@ static bool swipeFired = false;
 static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double dockGestureActivationVelocityFloor = 80.0;
-static const double nonInstantGestureVelocityLinearMultiplier = 5.0;
+static const double nonInstantGestureVelocityLinearMultiplier = 1.5;
 static const double nonInstantGestureVelocityQuadraticMultiplier = 0.1;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
-static const double nonInstantGestureProgress = 0.35;
+static const double nonInstantGestureProgress = 0.25;
 
 static ISSSwitchCallback switchCallback = NULL;
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -67,12 +67,12 @@ static bool swipeFired = false;
 // Gesture speed state
 static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
-static const double dockGestureActivationVelocityFloor = 80.0;
-static const double nonInstantGestureVelocityLinearMultiplier = 1.5;
-static const double nonInstantGestureVelocityQuadraticMultiplier = 0.1;
+static const double dockGestureActivationVelocityFloor = 70.0;
+static const double nonInstantGestureVelocityLinearMultiplier = 0.9;
+static const double nonInstantGestureVelocityQuadraticMultiplier = 0.035;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
-static const double nonInstantGestureProgress = 0.25;
+static const double nonInstantGestureProgress = 0.18;
 
 static ISSSwitchCallback switchCallback = NULL;
 

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -70,10 +70,11 @@ static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double nonInstantGestureVelocityLinearMultiplier = 0.45;
 static const double nonInstantGestureVelocityQuadraticMultiplier = 0.0175;
+static const double nonInstantGestureCommitVelocityFloor = 80.0;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
 static const double nonInstantGestureProgress = 0.09;
-static const double nonInstantGestureProgressCeiling = 0.35;
+static const double nonInstantGestureCommitProgress = 0.35;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -112,6 +113,10 @@ static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDispla
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity, const char *displayID);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
 static bool iss_should_block_switch(const ISSSpaceInfo *info, ISSDirection direction);
+double iss_dock_swipe_velocity_for_phase_and_refresh_rate(double velocity,
+                                                          int phase,
+                                                          double displayRefreshRate,
+                                                          double baselineRefreshRate);
 
 static double iss_base_gesture_velocity(double velocity) {
     if (velocity <= 0.0 || velocity >= instantGestureVelocity) {
@@ -169,20 +174,37 @@ double iss_normalize_gesture_velocity(double velocity) {
 }
 
 double iss_dock_swipe_velocity_for_phase(double velocity, int phase) {
-    (void)phase;
-    return iss_normalize_gesture_velocity(velocity);
+    return iss_dock_swipe_velocity_for_phase_and_refresh_rate(velocity, phase, 0.0, 0.0);
 }
 
 double iss_dock_swipe_velocity_for_phase_and_refresh_rate(double velocity,
                                                           int phase,
                                                           double displayRefreshRate,
                                                           double baselineRefreshRate) {
-    (void)phase;
-    return iss_normalize_gesture_velocity_for_refresh_rate(
+    double normalizedVelocity = iss_normalize_gesture_velocity_for_refresh_rate(
         velocity,
         displayRefreshRate,
         baselineRefreshRate
     );
+
+    if (phase != kCGSGesturePhaseEnded
+        || velocity <= nonInstantGestureVelocityFloor
+        || velocity >= instantGestureVelocity) {
+        return normalizedVelocity;
+    }
+
+    double refreshScale = iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
+    if (refreshScale < 1.0) {
+        refreshScale = 1.0;
+    }
+    double commitVelocityFloor = nonInstantGestureCommitVelocityFloor * refreshScale;
+    if (commitVelocityFloor >= instantGestureVelocity) {
+        commitVelocityFloor = nonInstantGestureVelocityCeiling;
+    }
+
+    return normalizedVelocity > commitVelocityFloor
+        ? normalizedVelocity
+        : commitVelocityFloor;
 }
 
 double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
@@ -195,14 +217,11 @@ double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
         return (double)FLT_TRUE_MIN;
     }
 
-    double progress = nonInstantGestureProgress;
     if (phase == kCGSGesturePhaseEnded) {
-        double refreshScale = iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
-        progress *= refreshScale * refreshScale;
+        return nonInstantGestureCommitProgress;
     }
-    return progress < nonInstantGestureProgressCeiling
-        ? progress
-        : nonInstantGestureProgressCeiling;
+
+    return nonInstantGestureProgress;
 }
 
 double iss_dock_swipe_progress_for_phase(double velocity, int phase) {

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -70,11 +70,9 @@ static double gestureSpeed = 2000.0;
 static const double nonInstantGestureVelocityFloor = 40.0;
 static const double nonInstantGestureVelocityLinearMultiplier = 0.45;
 static const double nonInstantGestureVelocityQuadraticMultiplier = 0.0175;
-static const double nonInstantGestureCommitVelocityFloor = 80.0;
 static const double instantGestureVelocity = 2000.0;
 static const double nonInstantGestureVelocityCeiling = 1999.0;
 static const double nonInstantGestureProgress = 0.09;
-static const double nonInstantGestureCommitProgress = 0.35;
 
 static ISSSwitchCallback switchCallback = NULL;
 
@@ -181,30 +179,12 @@ double iss_dock_swipe_velocity_for_phase_and_refresh_rate(double velocity,
                                                           int phase,
                                                           double displayRefreshRate,
                                                           double baselineRefreshRate) {
-    double normalizedVelocity = iss_normalize_gesture_velocity_for_refresh_rate(
+    (void)phase;
+    return iss_normalize_gesture_velocity_for_refresh_rate(
         velocity,
         displayRefreshRate,
         baselineRefreshRate
     );
-
-    if (phase != kCGSGesturePhaseEnded
-        || velocity <= nonInstantGestureVelocityFloor
-        || velocity >= instantGestureVelocity) {
-        return normalizedVelocity;
-    }
-
-    double refreshScale = iss_refresh_rate_normalization_scale(displayRefreshRate, baselineRefreshRate);
-    if (refreshScale < 1.0) {
-        refreshScale = 1.0;
-    }
-    double commitVelocityFloor = nonInstantGestureCommitVelocityFloor * refreshScale;
-    if (commitVelocityFloor >= instantGestureVelocity) {
-        commitVelocityFloor = nonInstantGestureVelocityCeiling;
-    }
-
-    return normalizedVelocity > commitVelocityFloor
-        ? normalizedVelocity
-        : commitVelocityFloor;
 }
 
 double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
@@ -215,10 +195,6 @@ double iss_dock_swipe_progress_for_phase_and_refresh_rate(double velocity,
         || velocity <= nonInstantGestureVelocityFloor
         || velocity >= instantGestureVelocity) {
         return (double)FLT_TRUE_MIN;
-    }
-
-    if (phase == kCGSGesturePhaseEnded) {
-        return nonInstantGestureCommitProgress;
     }
 
     return nonInstantGestureProgress;

--- a/Sources/ISS/ISS.c
+++ b/Sources/ISS/ISS.c
@@ -107,6 +107,8 @@ static bool extract_space_info_from_display(CFDictionaryRef displayDict,
                                             CGSSpaceID activeSpace,
                                             bool hasActiveSpace,
                                             ISSSpaceInfo *outInfo);
+static bool iss_install_event_tap(void);
+static void iss_destroy_event_tap(void);
 static bool load_space_info_for_display(ISSSpaceInfo *info, bool useCursorDisplay);
 static bool iss_perform_switch_gesture(ISSDirection direction, double velocity, const char *displayID);
 static bool iss_switch_with_info(const ISSSpaceInfo *info, ISSDirection direction);
@@ -780,12 +782,16 @@ void iss_set_overlay_detection_enabled(bool enabled) {
 }
 
 bool iss_init(void) {
-    if (globalTap) {
-        return true;
-    }
-
     if (!predictionsDict) {
         predictionsDict = CFDictionaryCreateMutable(NULL, 0, &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    }
+
+    return iss_install_event_tap();
+}
+
+static bool iss_install_event_tap(void) {
+    if (globalTap) {
+        return true;
     }
 
     CGEventMask mask = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp)
@@ -810,11 +816,7 @@ bool iss_init(void) {
     return true;
 }
 
-void iss_destroy(void) {
-    if (predictionsDict) {
-        CFRelease(predictionsDict);
-        predictionsDict = NULL;
-    }
+static void iss_destroy_event_tap(void) {
     if (globalTap) {
         CGEventTapEnable(globalTap, false);
         if (globalSource) {
@@ -824,6 +826,21 @@ void iss_destroy(void) {
         }
         CFRelease(globalTap);
         globalTap = NULL;
+    }
+}
+
+bool iss_reinstall_event_tap(void) {
+    swipeTracking = false;
+    swipeFired = false;
+    iss_destroy_event_tap();
+    return iss_install_event_tap();
+}
+
+void iss_destroy(void) {
+    iss_destroy_event_tap();
+    if (predictionsDict) {
+        CFRelease(predictionsDict);
+        predictionsDict = NULL;
     }
 }
 
@@ -913,6 +930,9 @@ bool iss_switch_to_index(unsigned int targetIndex) {
 
 void iss_set_swipe_override(bool enabled) {
     swipeOverrideEnabled = enabled;
+    if (enabled) {
+        (void)iss_reinstall_event_tap();
+    }
     if (!enabled) {
         swipeTracking = false;
         swipeFired = false;

--- a/Sources/ISS/include/ISS.h
+++ b/Sources/ISS/include/ISS.h
@@ -9,6 +9,16 @@
  */
 bool iss_init(void);
 
+/**
+ * @brief Recreates the session event tap without resetting predictions/settings.
+ *
+ * Useful after launch/login-item races: kCGHeadInsertEventTap only guarantees
+ * head position at install time, so a later app instance can otherwise receive
+ * physical swipe events before us.
+ * @return true on success, false on failure
+ */
+bool iss_reinstall_event_tap(void);
+
 /** @brief Clean up resources */
 void iss_destroy(void);
 

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -30,6 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    terminateSiblingInstantSpaceSwitcherApps()
     ensureAccessibilityPermission()
 
     if !iss_init() {
@@ -417,6 +418,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
           return
         }
         guard self.isSiblingInstantSpaceSwitcher(app) else { return }
+        app.terminate()
         self.scheduleSwipeOverrideTapRefresh()
       }
     }
@@ -435,6 +437,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     let bundlePrefix = "com.interversehq.InstantSpaceSwitcher"
     return bundleIdentifier == bundlePrefix || bundleIdentifier.hasPrefix("\(bundlePrefix).")
+  }
+
+  private func terminateSiblingInstantSpaceSwitcherApps() {
+    NSWorkspace.shared.runningApplications
+      .filter(isSiblingInstantSpaceSwitcher)
+      .forEach { $0.terminate() }
   }
 
 }

--- a/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
+++ b/Sources/InstantSpaceSwitcher/Core/AppDelegate.swift
@@ -13,6 +13,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var cancellables = Set<AnyCancellable>()
   private var spaceChangeObserver: Any?
   private var appActivationObserver: Any?
+  private var appLaunchObserver: Any?
+  private var swipeOverrideTapRefreshWorkItems: [DispatchWorkItem] = []
 
   func applicationWillFinishLaunching(_ notification: Notification) {
     NSAppleEventManager.shared().setEventHandler(
@@ -35,7 +37,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       retryIssInit()
     }
 
-    if UserDefaults.standard.bool(forKey: "swipeOverride") {
+    let swipeOverrideEnabled = UserDefaults.standard.bool(forKey: "swipeOverride")
+    if swipeOverrideEnabled {
       iss_set_swipe_override(true)
     }
 
@@ -46,6 +49,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     if UserDefaults.standard.object(forKey: "overlayDetectionEnabled") as? Bool ?? true {
       iss_set_overlay_detection_enabled(true)
+    }
+
+    if swipeOverrideEnabled {
+      scheduleSwipeOverrideTapRefresh()
     }
 
     iss_set_switch_callback { newSpaceIndex in
@@ -60,17 +67,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     bindHotkeys()
     observeSpaceChanges()
     observeAppActivation()
+    observeAppLaunches()
     refreshSpaceInfo()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
+    cancelSwipeOverrideTapRefresh()
     iss_destroy()
     stopObservingSpaceChanges()
     stopObservingAppActivation()
+    stopObservingAppLaunches()
   }
 
   private func retryIssInit() {
-    guard !iss_init() else { return }
+    guard !iss_init() else {
+      if UserDefaults.standard.bool(forKey: "swipeOverride") {
+        scheduleSwipeOverrideTapRefresh()
+      }
+      return
+    }
     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
       self?.retryIssInit()
     }
@@ -90,6 +105,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
     let options = [promptKey: true] as CFDictionary
     _ = AXIsProcessTrustedWithOptions(options)
+  }
+
+  private func scheduleSwipeOverrideTapRefresh() {
+    cancelSwipeOverrideTapRefresh()
+    guard UserDefaults.standard.bool(forKey: "swipeOverride") else { return }
+
+    // Login items can start multiple copies in either order. Reinstalling soon
+    // after launch keeps this process at the head of the session tap chain.
+    for delay in [0.25, 0.75, 1.5, 3.0] {
+      let workItem = DispatchWorkItem { [weak self] in
+        self?.refreshSwipeOverrideTap()
+      }
+      swipeOverrideTapRefreshWorkItems.append(workItem)
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+  }
+
+  private func cancelSwipeOverrideTapRefresh() {
+    swipeOverrideTapRefreshWorkItems.forEach { $0.cancel() }
+    swipeOverrideTapRefreshWorkItems.removeAll()
+  }
+
+  private func refreshSwipeOverrideTap() {
+    guard UserDefaults.standard.bool(forKey: "swipeOverride") else { return }
+
+    guard iss_reinstall_event_tap() else {
+      print("Failed to refresh ISS event tap")
+      retryIssInit()
+      return
+    }
   }
 
   private func setupMainMenu() {
@@ -357,6 +402,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       NSWorkspace.shared.notificationCenter.removeObserver(observer)
       appActivationObserver = nil
     }
+  }
+
+  private func observeAppLaunches() {
+    stopObservingAppLaunches()
+    appLaunchObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.didLaunchApplicationNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] notification in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
+          return
+        }
+        guard self.isSiblingInstantSpaceSwitcher(app) else { return }
+        self.scheduleSwipeOverrideTapRefresh()
+      }
+    }
+  }
+
+  private func stopObservingAppLaunches() {
+    if let observer = appLaunchObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(observer)
+      appLaunchObserver = nil
+    }
+  }
+
+  private func isSiblingInstantSpaceSwitcher(_ app: NSRunningApplication) -> Bool {
+    guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { return false }
+    guard let bundleIdentifier = app.bundleIdentifier else { return false }
+
+    let bundlePrefix = "com.interversehq.InstantSpaceSwitcher"
+    return bundleIdentifier == bundlePrefix || bundleIdentifier.hasPrefix("\(bundlePrefix).")
   }
 
 }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -253,10 +253,10 @@ final class GestureVelocityTests: XCTestCase {
 
     func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
-            (40.0, 80.0),
-            (50.0, 105.0),
-            (60.0, 150.0),
-            (80.0, 300.0),
+            (40.0, 70.0),
+            (50.0, 82.5),
+            (60.0, 102.0),
+            (80.0, 162.0),
             (2000.0, 2000.0),
         ]
 
@@ -266,14 +266,14 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 90.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 215.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 930.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 75.375, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 128.5, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 399.375, accuracy: 0.0001)
     }
 
     func testVelocityBelowPresetRangeUsesActivationFloor() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 80.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 70.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 70.0, accuracy: 0.0001)
     }
 
     func testNonInstantVelocityNeverBecomesInstant() {
@@ -327,14 +327,14 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testChangedAndEndedProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(150.0, gesturePhaseEnded), 0.25, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(300.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(70.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(102.0, gesturePhaseEnded), 0.18, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(162.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
     }
 
     func testProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.18, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -13,11 +13,37 @@ private func iss_is_mission_control_detected_in_window_list(_ windowList: CFArra
 @_silgen_name("iss_normalize_gesture_velocity")
 private func iss_normalize_gesture_velocity(_ velocity: Double) -> Double
 
+@_silgen_name("iss_refresh_rate_normalization_scale")
+private func iss_refresh_rate_normalization_scale(_ displayRefreshRate: Double, _ baselineRefreshRate: Double) -> Double
+
+@_silgen_name("iss_normalize_gesture_velocity_for_refresh_rate")
+private func iss_normalize_gesture_velocity_for_refresh_rate(
+    _ velocity: Double,
+    _ displayRefreshRate: Double,
+    _ baselineRefreshRate: Double
+) -> Double
+
 @_silgen_name("iss_dock_swipe_velocity_for_phase")
 private func iss_dock_swipe_velocity_for_phase(_ velocity: Double, _ phase: Int32) -> Double
 
+@_silgen_name("iss_dock_swipe_velocity_for_phase_and_refresh_rate")
+private func iss_dock_swipe_velocity_for_phase_and_refresh_rate(
+    _ velocity: Double,
+    _ phase: Int32,
+    _ displayRefreshRate: Double,
+    _ baselineRefreshRate: Double
+) -> Double
+
 @_silgen_name("iss_dock_swipe_progress_for_phase")
 private func iss_dock_swipe_progress_for_phase(_ velocity: Double, _ phase: Int32) -> Double
+
+@_silgen_name("iss_dock_swipe_progress_for_phase_and_refresh_rate")
+private func iss_dock_swipe_progress_for_phase_and_refresh_rate(
+    _ velocity: Double,
+    _ phase: Int32,
+    _ displayRefreshRate: Double,
+    _ baselineRefreshRate: Double
+) -> Double
 //
 // Window structures are hardcoded from real probe output (expose_probe.c) captured
 // on macOS Sequoia with two displays (1920x1080 primary, 1728x1117 secondary).
@@ -271,6 +297,29 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 204.6875, accuracy: 0.0001)
     }
 
+    func testRefreshNormalizationUsesBaselineRatio() {
+        XCTAssertEqual(iss_refresh_rate_normalization_scale(120.0, 120.0), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_refresh_rate_normalization_scale(240.0, 120.0), 2.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_refresh_rate_normalization_scale(180.0, 120.0), 1.5, accuracy: 0.0001)
+    }
+
+    func testUnknownRefreshRateUsesUnscaledVelocity() {
+        XCTAssertEqual(iss_refresh_rate_normalization_scale(0.0, 120.0), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_refresh_rate_normalization_scale(120.0, 0.0), 1.0, accuracy: 0.0001)
+    }
+
+    func testNonInstantVelocityScalesForHighRefreshDisplay() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(40.0, 240.0, 120.0), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(50.0, 240.0, 120.0), 52.5, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 240.0, 120.0), 72.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 240.0, 120.0), 132.0, accuracy: 0.0001)
+    }
+
+    func testNonInstantVelocityScalesOffsetOnlyForLowRefreshDisplay() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(40.0, 60.0, 120.0), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(50.0, 60.0, 120.0), 43.125, accuracy: 0.0001)
+    }
+
     func testVelocityBelowPresetRangeUsesActivationFloor() {
         XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 40.0, accuracy: 0.0001)
         XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 40.0, accuracy: 0.0001)
@@ -284,6 +333,8 @@ final class GestureVelocityTests: XCTestCase {
     func testInstantAndHigherVelocityAreUnchanged() {
         XCTAssertEqual(iss_normalize_gesture_velocity(2000.0), 2000.0, accuracy: 0.0001)
         XCTAssertEqual(iss_normalize_gesture_velocity(4000.0), 4000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(2000.0, 240.0, 120.0), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(4000.0, 240.0, 120.0), 4000.0, accuracy: 0.0001)
     }
 
     func testPresetOrderIsPreserved() {
@@ -335,6 +386,23 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(46.25, gesturePhaseChanged), 0.09, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(56.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(86.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
+    }
+
+    func testProgressDoesNotScaleWithRefreshRate() {
+        XCTAssertEqual(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 240.0, 120.0),
+            0.09,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 180.0, 120.0),
+            0.09,
+            accuracy: 0.0001
+        )
+        XCTAssertLessThan(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(40.0, gesturePhaseChanged, 240.0, 120.0),
+            0.0001
+        )
     }
 
     func testProgressIsConstantForNonInstantVelocity() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -254,9 +254,9 @@ final class GestureVelocityTests: XCTestCase {
     func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
             (40.0, 80.0),
-            (50.0, 140.0),
-            (60.0, 220.0),
-            (80.0, 440.0),
+            (50.0, 105.0),
+            (60.0, 150.0),
+            (80.0, 300.0),
             (2000.0, 2000.0),
         ]
 
@@ -266,9 +266,9 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 107.5, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 320.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 1227.5, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 90.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 215.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 930.0, accuracy: 0.0001)
     }
 
     func testVelocityBelowPresetRangeUsesActivationFloor() {
@@ -327,14 +327,14 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testChangedAndEndedProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(220.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(440.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(150.0, gesturePhaseEnded), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(300.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
     }
 
     func testProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.25, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -391,12 +391,17 @@ final class GestureVelocityTests: XCTestCase {
     func testProgressScalesWithRefreshRateForActivation() {
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 240.0, 120.0),
-            0.18,
+            0.09,
             accuracy: 0.0001
         )
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 180.0, 120.0),
-            0.135,
+            0.2025,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseEnded, 240.0, 120.0),
+            0.35,
             accuracy: 0.0001
         )
         XCTAssertEqual(
@@ -416,7 +421,7 @@ final class GestureVelocityTests: XCTestCase {
 
     func testScaledProgressIsCappedBelowAggressiveSwipeProgress() {
         XCTAssertEqual(
-            iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseChanged, 480.0, 60.0),
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 480.0, 60.0),
             0.35,
             accuracy: 0.0001
         )

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -10,11 +10,11 @@ private func iss_is_expose_detected_in_window_list(_ windowList: CFArray) -> Boo
 @_silgen_name("iss_is_mission_control_detected_in_window_list")
 private func iss_is_mission_control_detected_in_window_list(_ windowList: CFArray) -> Bool
 
-@_silgen_name("iss_normalize_gesture_velocity_for_refresh_rate")
-private func iss_normalize_gesture_velocity_for_refresh_rate(_ velocity: Double, _ refreshRate: Double) -> Double
+@_silgen_name("iss_normalize_gesture_velocity")
+private func iss_normalize_gesture_velocity(_ velocity: Double) -> Double
 
 @_silgen_name("iss_dock_swipe_velocity_for_phase")
-private func iss_dock_swipe_velocity_for_phase(_ velocity: Double, _ refreshRate: Double, _ phase: Int32) -> Double
+private func iss_dock_swipe_velocity_for_phase(_ velocity: Double, _ phase: Int32) -> Double
 
 @_silgen_name("iss_dock_swipe_progress_for_phase")
 private func iss_dock_swipe_progress_for_phase(_ velocity: Double, _ phase: Int32) -> Double
@@ -251,121 +251,85 @@ final class GestureVelocityTests: XCTestCase {
     private let gesturePhaseChanged: Int32 = 2
     private let gesturePhaseEnded: Int32 = 4
 
-    func testVelocityIsUnchangedAtReferenceRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 120.0), 60.0, accuracy: 0.0001)
-    }
-
-    func testVelocityScalesBelowReferenceRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 40.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 45.0, accuracy: 0.0001)
-    }
-
-    func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
+    func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
             (40.0, 80.0),
-            (50.0, 100.0),
-            (60.0, 120.0),
-            (80.0, 160.0),
+            (50.0, 90.0),
+            (60.0, 100.0),
+            (80.0, 120.0),
             (2000.0, 2000.0),
         ]
 
         for preset in presets {
-            XCTAssertEqual(
-                iss_normalize_gesture_velocity_for_refresh_rate(preset.input, 240.0),
-                preset.expected,
-                accuracy: 0.0001
-            )
+            XCTAssertEqual(iss_normalize_gesture_velocity(preset.input), preset.expected, accuracy: 0.0001)
         }
     }
 
-    func testUnknownRefreshRateLeavesVelocityUnchanged() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 0.0), 80.0, accuracy: 0.0001)
+    func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 85.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 110.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 165.0, accuracy: 0.0001)
     }
 
-    func testNonInstantVelocityDoesNotReachInstantAtCommonHighRefreshRates() {
-        for refreshRate in [144.0, 165.0, 240.0, 360.0] {
-            XCTAssertLessThan(iss_normalize_gesture_velocity_for_refresh_rate(80.0, refreshRate), 2000.0)
+    func testVelocityBelowPresetRangeUsesActivationFloor() {
+        XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testNonInstantVelocityNeverBecomesInstant() {
+        XCTAssertEqual(iss_normalize_gesture_velocity(1999.0), 1999.0, accuracy: 0.0001)
+        XCTAssertLessThan(iss_normalize_gesture_velocity(1999.0), 2000.0)
+    }
+
+    func testInstantAndHigherVelocityAreUnchanged() {
+        XCTAssertEqual(iss_normalize_gesture_velocity(2000.0), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(4000.0), 4000.0, accuracy: 0.0001)
+    }
+
+    func testPresetOrderIsPreserved() {
+        let normalized = [40.0, 50.0, 60.0, 80.0, 2000.0].map(iss_normalize_gesture_velocity)
+
+        for index in 1..<normalized.count {
+            XCTAssertGreaterThan(normalized[index], normalized[index - 1])
         }
     }
 
-    func testNonInstantVelocityDoesNotExceedInstantPreset() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 3000.0), 2000.0, accuracy: 0.0001)
-    }
-
-    func testFasterPresetStaysBelowPreviousFastestCompensationAt240Hz() {
-        XCTAssertLessThan(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 240.0), 300.0)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 240.0), 160.0, accuracy: 0.0001)
-    }
-
-    func testMultiSpaceVelocityAboveInstantIsUnchanged() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(4000.0, 240.0), 4000.0, accuracy: 0.0001)
-    }
-
-    func testPresetOrderIsPreservedAcrossSupportedRefreshRates() {
-        let presets = [40.0, 50.0, 60.0, 80.0, 2000.0]
-
-        for refreshRate in [30.0, 60.0, 75.0, 90.0, 120.0, 144.0, 165.0, 240.0, 360.0] {
-            let normalized = presets.map {
-                iss_normalize_gesture_velocity_for_refresh_rate($0, refreshRate)
-            }
-
-            for index in 1..<normalized.count {
-                XCTAssertGreaterThan(normalized[index], normalized[index - 1])
-            }
-        }
-    }
-
-    func testAnimationPhasesUseRefreshNormalizedVelocity() {
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 120.0, gesturePhaseBegan), 60.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 120.0, gesturePhaseChanged), 60.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 240.0, gesturePhaseChanged), 120.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(80.0, 240.0, gesturePhaseChanged), 160.0, accuracy: 0.0001)
-    }
-
-    func testEndedPhaseKeepsRefreshNormalizedVelocityForNonInstantPresets() {
+    func testAllPhasesUseSameNormalizedVelocity() {
         let presets = [40.0, 50.0, 60.0, 80.0]
 
-        for refreshRate in [60.0, 120.0, 144.0, 240.0, 360.0] {
-            for preset in presets {
-                let changed = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseChanged)
-                let ended = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseEnded)
+        for preset in presets {
+            let expected = iss_normalize_gesture_velocity(preset)
+            let began = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseBegan)
+            let changed = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseChanged)
+            let ended = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseEnded)
 
-                XCTAssertEqual(changed, ended, accuracy: 0.0001)
-                XCTAssertLessThan(ended, 2000.0)
-            }
+            XCTAssertEqual(began, expected, accuracy: 0.0001)
+            XCTAssertEqual(changed, expected, accuracy: 0.0001)
+            XCTAssertEqual(ended, expected, accuracy: 0.0001)
         }
     }
 
     func testInstantPresetRemainsInstantForAllPhases() {
-        for refreshRate in [120.0, 240.0] {
-            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseBegan), 2000.0, accuracy: 0.0001)
-            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseChanged), 2000.0, accuracy: 0.0001)
-            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseEnded), 2000.0, accuracy: 0.0001)
-        }
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, gesturePhaseBegan), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, gesturePhaseChanged), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, gesturePhaseEnded), 2000.0, accuracy: 0.0001)
     }
 
     func testMultiSpaceVelocityAboveInstantIsNotReducedForAnyPhase() {
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseBegan), 4000.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseChanged), 4000.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseEnded), 4000.0, accuracy: 0.0001)
-    }
-
-    func testUnknownRefreshRateKeepsVelocityForAllPhases() {
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseChanged), 60.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseEnded), 60.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, gesturePhaseBegan), 4000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, gesturePhaseChanged), 4000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, gesturePhaseEnded), 4000.0, accuracy: 0.0001)
     }
 
     func testBeganPhaseUsesMinimalProgress() {
-        XCTAssertGreaterThan(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseBegan), 0.0)
-        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseBegan), 0.0001)
+        XCTAssertGreaterThan(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseBegan), 0.0)
+        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseBegan), 0.0001)
     }
 
     func testChangedAndEndedProgressScaleWithVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseChanged), 0.125, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseEnded), 0.125, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 1.0 / 6.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseEnded), 5.0 / 24.0, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(120.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(160.0, gesturePhaseEnded), 1.0 / 3.0, accuracy: 0.0001)
     }
 
     func testProgressIsCappedBelowFullSwipeDistance() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -254,9 +254,9 @@ final class GestureVelocityTests: XCTestCase {
     func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
             (40.0, 80.0),
-            (50.0, 110.0),
-            (60.0, 140.0),
-            (80.0, 200.0),
+            (50.0, 140.0),
+            (60.0, 220.0),
+            (80.0, 440.0),
             (2000.0, 2000.0),
         ]
 
@@ -266,9 +266,9 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 95.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 170.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 335.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 107.5, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 320.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 1227.5, accuracy: 0.0001)
     }
 
     func testVelocityBelowPresetRangeUsesActivationFloor() {
@@ -326,15 +326,15 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertLessThan(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseBegan), 0.0001)
     }
 
-    func testChangedAndEndedProgressScaleWithVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 1.0 / 6.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(140.0, gesturePhaseEnded), 7.0 / 24.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(200.0, gesturePhaseChanged), 5.0 / 12.0, accuracy: 0.0001)
+    func testChangedAndEndedProgressIsConstantForNonInstantVelocity() {
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(220.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(440.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
     }
 
-    func testProgressIsCappedBelowFullSwipeDistance() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.8, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.8, accuracy: 0.0001)
+    func testProgressIsConstantForNonInstantVelocity() {
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -9,6 +9,9 @@ private func iss_is_expose_detected_in_window_list(_ windowList: CFArray) -> Boo
 
 @_silgen_name("iss_is_mission_control_detected_in_window_list")
 private func iss_is_mission_control_detected_in_window_list(_ windowList: CFArray) -> Bool
+
+@_silgen_name("iss_normalize_gesture_velocity_for_refresh_rate")
+private func iss_normalize_gesture_velocity_for_refresh_rate(_ velocity: Double, _ refreshRate: Double) -> Double
 //
 // Window structures are hardcoded from real probe output (expose_probe.c) captured
 // on macOS Sequoia with two displays (1920x1080 primary, 1728x1117 secondary).
@@ -234,5 +237,59 @@ final class OverlayDetectionTests: XCTestCase {
         ]
         XCTAssertTrue(iss_is_expose_detected_in_window_list(list as CFArray), "should detect App Exposé on single display")
         XCTAssertFalse(iss_is_mission_control_detected_in_window_list(list as CFArray))
+    }
+}
+
+final class GestureVelocityTests: XCTestCase {
+    func testVelocityIsUnchangedAtReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testVelocityIsUnchangedBelowReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
+        let presets: [(input: Double, expected: Double)] = [
+            (40.0, 200.0),
+            (50.0, 250.0),
+            (60.0, 300.0),
+            (80.0, 400.0),
+            (2000.0, 2000.0),
+        ]
+
+        for preset in presets {
+            XCTAssertEqual(
+                iss_normalize_gesture_velocity_for_refresh_rate(preset.input, 240.0),
+                preset.expected,
+                accuracy: 0.0001
+            )
+        }
+    }
+
+    func testUnknownRefreshRateLeavesVelocityUnchanged() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 0.0), 80.0, accuracy: 0.0001)
+    }
+
+    func testNonInstantVelocityDoesNotExceedInstantPreset() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 1000.0), 2000.0, accuracy: 0.0001)
+    }
+
+    func testMultiSpaceVelocityAboveInstantIsUnchanged() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(4000.0, 240.0), 4000.0, accuracy: 0.0001)
+    }
+
+    func testPresetOrderIsPreservedAcrossSupportedRefreshRates() {
+        let presets = [40.0, 50.0, 60.0, 80.0, 2000.0]
+
+        for refreshRate in [60.0, 120.0, 144.0, 165.0, 240.0, 360.0] {
+            let normalized = presets.map {
+                iss_normalize_gesture_velocity_for_refresh_rate($0, refreshRate)
+            }
+
+            for index in 1..<normalized.count {
+                XCTAssertGreaterThan(normalized[index], normalized[index - 1])
+            }
+        }
     }
 }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -253,10 +253,10 @@ final class GestureVelocityTests: XCTestCase {
 
     func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
-            (40.0, 70.0),
-            (50.0, 82.5),
-            (60.0, 102.0),
-            (80.0, 162.0),
+            (40.0, 40.0),
+            (50.0, 46.25),
+            (60.0, 56.0),
+            (80.0, 86.0),
             (2000.0, 2000.0),
         ]
 
@@ -266,14 +266,14 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 75.375, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 128.5, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 399.375, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 42.6875, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 69.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 204.6875, accuracy: 0.0001)
     }
 
     func testVelocityBelowPresetRangeUsesActivationFloor() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 70.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 70.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(1.0), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(39.0), 40.0, accuracy: 0.0001)
     }
 
     func testNonInstantVelocityNeverBecomesInstant() {
@@ -326,15 +326,20 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertLessThan(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseBegan), 0.0001)
     }
 
-    func testChangedAndEndedProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(70.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(102.0, gesturePhaseEnded), 0.18, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(162.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
+    func testNormalPresetUsesMinimalProgress() {
+        XCTAssertGreaterThan(iss_dock_swipe_progress_for_phase(40.0, gesturePhaseChanged), 0.0)
+        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(40.0, gesturePhaseChanged), 0.0001)
+    }
+
+    func testChangedAndEndedProgressIsConstantForFastNonInstantVelocity() {
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(46.25, gesturePhaseChanged), 0.09, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(56.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(86.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
     }
 
     func testProgressIsConstantForNonInstantVelocity() {
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.18, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.18, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -388,20 +388,37 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(86.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
     }
 
-    func testProgressDoesNotScaleWithRefreshRate() {
+    func testProgressScalesWithRefreshRateForActivation() {
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 240.0, 120.0),
-            0.09,
+            0.18,
             accuracy: 0.0001
         )
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 180.0, 120.0),
+            0.135,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 0.0, 120.0),
             0.09,
             accuracy: 0.0001
         )
         XCTAssertLessThan(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(40.0, gesturePhaseChanged, 240.0, 120.0),
             0.0001
+        )
+        XCTAssertLessThan(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(2000.0, gesturePhaseChanged, 240.0, 120.0),
+            0.0001
+        )
+    }
+
+    func testScaledProgressIsCappedBelowAggressiveSwipeProgress() {
+        XCTAssertEqual(
+            iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseChanged, 480.0, 60.0),
+            0.35,
+            accuracy: 0.0001
         )
     }
 

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -241,22 +241,22 @@ final class OverlayDetectionTests: XCTestCase {
 }
 
 final class GestureVelocityTests: XCTestCase {
-    func testVelocityScalesAtPivotRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 160.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 120.0), 120.0, accuracy: 0.0001)
+    func testVelocityIsUnchangedAtReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 120.0), 60.0, accuracy: 0.0001)
     }
 
-    func testVelocityScalesBetweenLowReferenceAndPivotRefreshRates() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 80.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 90.0, accuracy: 0.0001)
+    func testVelocityScalesBelowReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 45.0, accuracy: 0.0001)
     }
 
     func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
         let presets: [(input: Double, expected: Double)] = [
-            (40.0, 200.0),
-            (50.0, 225.0),
-            (60.0, 250.0),
-            (80.0, 300.0),
+            (40.0, 80.0),
+            (50.0, 100.0),
+            (60.0, 120.0),
+            (80.0, 160.0),
             (2000.0, 2000.0),
         ]
 
@@ -280,12 +280,12 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityDoesNotExceedInstantPreset() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 2000.0), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 3000.0), 2000.0, accuracy: 0.0001)
     }
 
     func testFasterPresetStaysBelowPreviousFastestCompensationAt240Hz() {
         XCTAssertLessThan(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 240.0), 300.0)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 240.0), 300.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 240.0), 160.0, accuracy: 0.0001)
     }
 
     func testMultiSpaceVelocityAboveInstantIsUnchanged() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -252,9 +252,9 @@ final class GestureVelocityTests: XCTestCase {
     func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
         let presets: [(input: Double, expected: Double)] = [
             (40.0, 200.0),
-            (50.0, 250.0),
-            (60.0, 300.0),
-            (80.0, 400.0),
+            (50.0, 225.0),
+            (60.0, 250.0),
+            (80.0, 300.0),
             (2000.0, 2000.0),
         ]
 
@@ -271,8 +271,19 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 0.0), 80.0, accuracy: 0.0001)
     }
 
+    func testNonInstantVelocityDoesNotReachInstantAtCommonHighRefreshRates() {
+        for refreshRate in [144.0, 165.0, 240.0, 360.0] {
+            XCTAssertLessThan(iss_normalize_gesture_velocity_for_refresh_rate(80.0, refreshRate), 2000.0)
+        }
+    }
+
     func testNonInstantVelocityDoesNotExceedInstantPreset() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 1000.0), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 2000.0), 2000.0, accuracy: 0.0001)
+    }
+
+    func testFasterPresetStaysBelowPreviousFastestCompensationAt240Hz() {
+        XCTAssertLessThan(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 240.0), 300.0)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 240.0), 300.0, accuracy: 0.0001)
     }
 
     func testMultiSpaceVelocityAboveInstantIsUnchanged() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -241,13 +241,14 @@ final class OverlayDetectionTests: XCTestCase {
 }
 
 final class GestureVelocityTests: XCTestCase {
-    func testVelocityIsUnchangedAtReferenceRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
+    func testVelocityScalesAtPivotRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 160.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 120.0), 120.0, accuracy: 0.0001)
     }
 
-    func testVelocityScalesBelowReferenceRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 40.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 45.0, accuracy: 0.0001)
+    func testVelocityScalesBetweenLowReferenceAndPivotRefreshRates() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 90.0, accuracy: 0.0001)
     }
 
     func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -15,6 +15,9 @@ private func iss_normalize_gesture_velocity_for_refresh_rate(_ velocity: Double,
 
 @_silgen_name("iss_dock_swipe_velocity_for_phase")
 private func iss_dock_swipe_velocity_for_phase(_ velocity: Double, _ refreshRate: Double, _ phase: Int32) -> Double
+
+@_silgen_name("iss_dock_swipe_progress_for_phase")
+private func iss_dock_swipe_progress_for_phase(_ velocity: Double, _ phase: Int32) -> Double
 //
 // Window structures are hardcoded from real probe output (expose_probe.c) captured
 // on macOS Sequoia with two displays (1920x1080 primary, 1728x1117 secondary).
@@ -320,7 +323,7 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_dock_swipe_velocity_for_phase(80.0, 240.0, gesturePhaseChanged), 160.0, accuracy: 0.0001)
     }
 
-    func testEndedPhaseUsesInstantCommitVelocityForNonInstantPresets() {
+    func testEndedPhaseKeepsRefreshNormalizedVelocityForNonInstantPresets() {
         let presets = [40.0, 50.0, 60.0, 80.0]
 
         for refreshRate in [60.0, 120.0, 144.0, 240.0, 360.0] {
@@ -328,8 +331,8 @@ final class GestureVelocityTests: XCTestCase {
                 let changed = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseChanged)
                 let ended = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseEnded)
 
-                XCTAssertLessThan(changed, ended)
-                XCTAssertEqual(ended, 2000.0, accuracy: 0.0001)
+                XCTAssertEqual(changed, ended, accuracy: 0.0001)
+                XCTAssertLessThan(ended, 2000.0)
             }
         }
     }
@@ -348,8 +351,30 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseEnded), 4000.0, accuracy: 0.0001)
     }
 
-    func testUnknownRefreshRateKeepsAnimationVelocityButStillCommitsImmediately() {
+    func testUnknownRefreshRateKeepsVelocityForAllPhases() {
         XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseChanged), 60.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseEnded), 2000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseEnded), 60.0, accuracy: 0.0001)
+    }
+
+    func testBeganPhaseUsesMinimalProgress() {
+        XCTAssertGreaterThan(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseBegan), 0.0)
+        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseBegan), 0.0001)
+    }
+
+    func testChangedAndEndedProgressScaleWithVelocity() {
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseChanged), 0.125, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(60.0, gesturePhaseEnded), 0.125, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(120.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(160.0, gesturePhaseEnded), 1.0 / 3.0, accuracy: 0.0001)
+    }
+
+    func testProgressIsCappedBelowFullSwipeDistance() {
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.8, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.8, accuracy: 0.0001)
+    }
+
+    func testInstantAndMultiSpaceVelocityUseMinimalProgress() {
+        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(2000.0, gesturePhaseChanged), 0.0001)
+        XCTAssertLessThan(iss_dock_swipe_progress_for_phase(4000.0, gesturePhaseEnded), 0.0001)
     }
 }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -345,19 +345,37 @@ final class GestureVelocityTests: XCTestCase {
         }
     }
 
-    func testAllPhasesUseSameNormalizedVelocity() {
+    func testBeganAndChangedPhasesUseAnimationVelocity() {
         let presets = [40.0, 50.0, 60.0, 80.0]
 
         for preset in presets {
             let expected = iss_normalize_gesture_velocity(preset)
             let began = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseBegan)
             let changed = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseChanged)
-            let ended = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseEnded)
 
             XCTAssertEqual(began, expected, accuracy: 0.0001)
             XCTAssertEqual(changed, expected, accuracy: 0.0001)
-            XCTAssertEqual(ended, expected, accuracy: 0.0001)
         }
+    }
+
+    func testEndedPhaseUsesCommitVelocityFloorForFastPresets() {
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(40.0, gesturePhaseEnded), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(50.0, gesturePhaseEnded), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, gesturePhaseEnded), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(80.0, gesturePhaseEnded), 86.0, accuracy: 0.0001)
+    }
+
+    func testEndedPhaseCommitVelocityScalesForHighRefreshDisplay() {
+        XCTAssertEqual(
+            iss_dock_swipe_velocity_for_phase_and_refresh_rate(60.0, gesturePhaseChanged, 240.0, 120.0),
+            72.0,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            iss_dock_swipe_velocity_for_phase_and_refresh_rate(60.0, gesturePhaseEnded, 240.0, 120.0),
+            160.0,
+            accuracy: 0.0001
+        )
     }
 
     func testInstantPresetRemainsInstantForAllPhases() {
@@ -382,13 +400,12 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertLessThan(iss_dock_swipe_progress_for_phase(40.0, gesturePhaseChanged), 0.0001)
     }
 
-    func testChangedAndEndedProgressIsConstantForFastNonInstantVelocity() {
+    func testChangedProgressUsesAnimationProgress() {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(46.25, gesturePhaseChanged), 0.09, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(56.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(86.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
     }
 
-    func testProgressScalesWithRefreshRateForActivation() {
+    func testEndedProgressUsesCommitProgress() {
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 240.0, 120.0),
             0.09,
@@ -396,7 +413,7 @@ final class GestureVelocityTests: XCTestCase {
         )
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 180.0, 120.0),
-            0.2025,
+            0.35,
             accuracy: 0.0001
         )
         XCTAssertEqual(
@@ -419,7 +436,7 @@ final class GestureVelocityTests: XCTestCase {
         )
     }
 
-    func testScaledProgressIsCappedBelowAggressiveSwipeProgress() {
+    func testEndedCommitProgressDoesNotExceedCommitProgress() {
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 480.0, 60.0),
             0.35,
@@ -427,9 +444,9 @@ final class GestureVelocityTests: XCTestCase {
         )
     }
 
-    func testProgressIsConstantForNonInstantVelocity() {
+    func testAnimationAndCommitProgressForNonInstantVelocity() {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -245,8 +245,9 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
     }
 
-    func testVelocityIsUnchangedBelowReferenceRefreshRate() {
-        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 80.0, accuracy: 0.0001)
+    func testVelocityScalesBelowReferenceRefreshRate() {
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 60.0), 40.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 90.0), 45.0, accuracy: 0.0001)
     }
 
     func testAllPresetVelocitiesScaleAboveReferenceRefreshRate() {
@@ -293,7 +294,7 @@ final class GestureVelocityTests: XCTestCase {
     func testPresetOrderIsPreservedAcrossSupportedRefreshRates() {
         let presets = [40.0, 50.0, 60.0, 80.0, 2000.0]
 
-        for refreshRate in [60.0, 120.0, 144.0, 165.0, 240.0, 360.0] {
+        for refreshRate in [30.0, 60.0, 75.0, 90.0, 120.0, 144.0, 165.0, 240.0, 360.0] {
             let normalized = presets.map {
                 iss_normalize_gesture_velocity_for_refresh_rate($0, refreshRate)
             }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -12,6 +12,9 @@ private func iss_is_mission_control_detected_in_window_list(_ windowList: CFArra
 
 @_silgen_name("iss_normalize_gesture_velocity_for_refresh_rate")
 private func iss_normalize_gesture_velocity_for_refresh_rate(_ velocity: Double, _ refreshRate: Double) -> Double
+
+@_silgen_name("iss_dock_swipe_velocity_for_phase")
+private func iss_dock_swipe_velocity_for_phase(_ velocity: Double, _ refreshRate: Double, _ phase: Int32) -> Double
 //
 // Window structures are hardcoded from real probe output (expose_probe.c) captured
 // on macOS Sequoia with two displays (1920x1080 primary, 1728x1117 secondary).
@@ -241,6 +244,10 @@ final class OverlayDetectionTests: XCTestCase {
 }
 
 final class GestureVelocityTests: XCTestCase {
+    private let gesturePhaseBegan: Int32 = 1
+    private let gesturePhaseChanged: Int32 = 2
+    private let gesturePhaseEnded: Int32 = 4
+
     func testVelocityIsUnchangedAtReferenceRefreshRate() {
         XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(80.0, 120.0), 80.0, accuracy: 0.0001)
         XCTAssertEqual(iss_normalize_gesture_velocity_for_refresh_rate(60.0, 120.0), 60.0, accuracy: 0.0001)
@@ -304,5 +311,45 @@ final class GestureVelocityTests: XCTestCase {
                 XCTAssertGreaterThan(normalized[index], normalized[index - 1])
             }
         }
+    }
+
+    func testAnimationPhasesUseRefreshNormalizedVelocity() {
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 120.0, gesturePhaseBegan), 60.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 120.0, gesturePhaseChanged), 60.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 240.0, gesturePhaseChanged), 120.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(80.0, 240.0, gesturePhaseChanged), 160.0, accuracy: 0.0001)
+    }
+
+    func testEndedPhaseUsesInstantCommitVelocityForNonInstantPresets() {
+        let presets = [40.0, 50.0, 60.0, 80.0]
+
+        for refreshRate in [60.0, 120.0, 144.0, 240.0, 360.0] {
+            for preset in presets {
+                let changed = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseChanged)
+                let ended = iss_dock_swipe_velocity_for_phase(preset, refreshRate, gesturePhaseEnded)
+
+                XCTAssertLessThan(changed, ended)
+                XCTAssertEqual(ended, 2000.0, accuracy: 0.0001)
+            }
+        }
+    }
+
+    func testInstantPresetRemainsInstantForAllPhases() {
+        for refreshRate in [120.0, 240.0] {
+            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseBegan), 2000.0, accuracy: 0.0001)
+            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseChanged), 2000.0, accuracy: 0.0001)
+            XCTAssertEqual(iss_dock_swipe_velocity_for_phase(2000.0, refreshRate, gesturePhaseEnded), 2000.0, accuracy: 0.0001)
+        }
+    }
+
+    func testMultiSpaceVelocityAboveInstantIsNotReducedForAnyPhase() {
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseBegan), 4000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseChanged), 4000.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(4000.0, 240.0, gesturePhaseEnded), 4000.0, accuracy: 0.0001)
+    }
+
+    func testUnknownRefreshRateKeepsAnimationVelocityButStillCommitsImmediately() {
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseChanged), 60.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, 0.0, gesturePhaseEnded), 2000.0, accuracy: 0.0001)
     }
 }

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -254,9 +254,9 @@ final class GestureVelocityTests: XCTestCase {
     func testAllPresetsUseSharedActivationCurve() {
         let presets: [(input: Double, expected: Double)] = [
             (40.0, 80.0),
-            (50.0, 90.0),
-            (60.0, 100.0),
-            (80.0, 120.0),
+            (50.0, 110.0),
+            (60.0, 140.0),
+            (80.0, 200.0),
             (2000.0, 2000.0),
         ]
 
@@ -266,9 +266,9 @@ final class GestureVelocityTests: XCTestCase {
     }
 
     func testNonInstantVelocityUsesFormulaInsteadOfPresetMapping() {
-        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 85.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 110.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 165.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(45.0), 95.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(70.0), 170.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_normalize_gesture_velocity(125.0), 335.0, accuracy: 0.0001)
     }
 
     func testVelocityBelowPresetRangeUsesActivationFloor() {
@@ -328,8 +328,8 @@ final class GestureVelocityTests: XCTestCase {
 
     func testChangedAndEndedProgressScaleWithVelocity() {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(80.0, gesturePhaseChanged), 1.0 / 6.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(100.0, gesturePhaseEnded), 5.0 / 24.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(120.0, gesturePhaseChanged), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(140.0, gesturePhaseEnded), 7.0 / 24.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(200.0, gesturePhaseChanged), 5.0 / 12.0, accuracy: 0.0001)
     }
 
     func testProgressIsCappedBelowFullSwipeDistance() {

--- a/Tests/ISSTests/ExposeMcDetectTests.swift
+++ b/Tests/ISSTests/ExposeMcDetectTests.swift
@@ -345,27 +345,29 @@ final class GestureVelocityTests: XCTestCase {
         }
     }
 
-    func testBeganAndChangedPhasesUseAnimationVelocity() {
+    func testAllPhasesUseAnimationVelocity() {
         let presets = [40.0, 50.0, 60.0, 80.0]
 
         for preset in presets {
             let expected = iss_normalize_gesture_velocity(preset)
             let began = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseBegan)
             let changed = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseChanged)
+            let ended = iss_dock_swipe_velocity_for_phase(preset, gesturePhaseEnded)
 
             XCTAssertEqual(began, expected, accuracy: 0.0001)
             XCTAssertEqual(changed, expected, accuracy: 0.0001)
+            XCTAssertEqual(ended, expected, accuracy: 0.0001)
         }
     }
 
-    func testEndedPhaseUsesCommitVelocityFloorForFastPresets() {
+    func testEndedPhaseDoesNotOverrideAnimationVelocity() {
         XCTAssertEqual(iss_dock_swipe_velocity_for_phase(40.0, gesturePhaseEnded), 40.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(50.0, gesturePhaseEnded), 80.0, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, gesturePhaseEnded), 80.0, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(50.0, gesturePhaseEnded), 46.25, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_velocity_for_phase(60.0, gesturePhaseEnded), 56.0, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_velocity_for_phase(80.0, gesturePhaseEnded), 86.0, accuracy: 0.0001)
     }
 
-    func testEndedPhaseCommitVelocityScalesForHighRefreshDisplay() {
+    func testEndedPhaseUsesSameRefreshScaledVelocityAsChangedPhase() {
         XCTAssertEqual(
             iss_dock_swipe_velocity_for_phase_and_refresh_rate(60.0, gesturePhaseChanged, 240.0, 120.0),
             72.0,
@@ -373,9 +375,31 @@ final class GestureVelocityTests: XCTestCase {
         )
         XCTAssertEqual(
             iss_dock_swipe_velocity_for_phase_and_refresh_rate(60.0, gesturePhaseEnded, 240.0, 120.0),
-            160.0,
+            72.0,
             accuracy: 0.0001
         )
+    }
+
+    func testHighRefreshEndedPhasePreservesPresetSpacing() {
+        let presets: [(input: Double, expected: Double)] = [
+            (40.0, 40.0),
+            (50.0, 52.5),
+            (60.0, 72.0),
+            (80.0, 132.0),
+        ]
+
+        for preset in presets {
+            XCTAssertEqual(
+                iss_dock_swipe_velocity_for_phase_and_refresh_rate(
+                    preset.input,
+                    gesturePhaseEnded,
+                    240.0,
+                    120.0
+                ),
+                preset.expected,
+                accuracy: 0.0001
+            )
+        }
     }
 
     func testInstantPresetRemainsInstantForAllPhases() {
@@ -400,12 +424,13 @@ final class GestureVelocityTests: XCTestCase {
         XCTAssertLessThan(iss_dock_swipe_progress_for_phase(40.0, gesturePhaseChanged), 0.0001)
     }
 
-    func testChangedProgressUsesAnimationProgress() {
+    func testChangedAndEndedProgressUseAnimationProgress() {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(46.25, gesturePhaseChanged), 0.09, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(56.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(86.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
     }
 
-    func testEndedProgressUsesCommitProgress() {
+    func testProgressDoesNotScaleWithRefreshRate() {
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseChanged, 240.0, 120.0),
             0.09,
@@ -413,12 +438,12 @@ final class GestureVelocityTests: XCTestCase {
         )
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 180.0, 120.0),
-            0.35,
+            0.09,
             accuracy: 0.0001
         )
         XCTAssertEqual(
             iss_dock_swipe_progress_for_phase_and_refresh_rate(50.0, gesturePhaseEnded, 240.0, 120.0),
-            0.35,
+            0.09,
             accuracy: 0.0001
         )
         XCTAssertEqual(
@@ -436,17 +461,9 @@ final class GestureVelocityTests: XCTestCase {
         )
     }
 
-    func testEndedCommitProgressDoesNotExceedCommitProgress() {
-        XCTAssertEqual(
-            iss_dock_swipe_progress_for_phase_and_refresh_rate(80.0, gesturePhaseEnded, 480.0, 60.0),
-            0.35,
-            accuracy: 0.0001
-        )
-    }
-
-    func testAnimationAndCommitProgressForNonInstantVelocity() {
+    func testProgressIsConstantForNonInstantVelocity() {
         XCTAssertEqual(iss_dock_swipe_progress_for_phase(1000.0, gesturePhaseChanged), 0.09, accuracy: 0.0001)
-        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.35, accuracy: 0.0001)
+        XCTAssertEqual(iss_dock_swipe_progress_for_phase(1999.0, gesturePhaseEnded), 0.09, accuracy: 0.0001)
     }
 
     func testInstantAndMultiSpaceVelocityUseMinimalProgress() {


### PR DESCRIPTION
## Summary

- normalize non-instant speed presets with one display-aware formula instead of a preset lookup table
- preserve `Normal` as the original raw gesture behavior on every display: velocity `40` and near-zero progress
- scale only the speed offset above `Normal` by the target display refresh rate relative to the slowest active display
- keep `Began`, `Changed`, and `Ended` on the same animation velocity/progress so Fast/Faster/Fastest do not collapse into an instant-looking jump
- keep Fast / Faster / Fastest distinct while compensating high-refresh displays such as 240Hz vs 120Hz
- keep Instant and intentionally higher multi-space velocities unchanged
- resolve the target display through the selected `ISSSpaceInfo.displayID`, not by re-reading cursor position during gesture posting
- reassert the swipe-override event tap after launch/login-item races so a second app copy cannot stay ahead in the session tap chain after reboot
- prevent duplicate InstantSpaceSwitcher instances from keeping their own swipe taps by terminating sibling app instances with the same bundle-id prefix
- support macOS 27 physical swipes from both observed paths:
  - FluidTouchGesture / Swipe event type `31`
  - generic Gesture event type `29` with HID type `32` and progress in private field `119`
- keep the source-pid recursion guard only for legacy DockControl `30`; macOS 27 gesture events can be brokered or synthesized with a non-kernel PID
- register startup defaults so a fresh/new bundle defaults-domain does not silently start with swipe override disabled; explicit user settings still win
- explicitly request CoreGraphics listen/post event access before installing the event tap

## Root Cause

There are two separate Dock behaviors involved:

- velocity controls perceived animation speed
- progress participates in whether Dock commits/activates the target Space

The earlier high-refresh bug came from treating `Ended` as a separate aggressive commit phase. Because this app posts `Began`, `Changed`, and `Ended` immediately back-to-back, the final `Ended` event dominated the gesture. Fast and Faster were forced to the same commit velocity/progress, so all non-instant presets looked jerky and almost instant.

The current gesture fix removes that phase override. Each non-instant preset keeps its own velocity/progress through every phase.

A reboot-specific issue was also reproduced locally: macOS launched both the dev bundle and the installed Homebrew bundle at login. The installed bundle (`/Applications/InstantSpaceSwitcher.app`, commit `c99a076`) still posted `velocity=2000`, while the dev bundle posted the corrected non-instant values. Since `kCGHeadInsertEventTap` is only head-of-chain at install time, whichever copy installs later can intercept physical swipe events first.

macOS 27 introduced another breakage for physical swipes. Initial probing showed the new DockControls extension process and a possible type `31` path, but post-reboot physical captures showed the actual failing path on this machine as generic type `29`, HID type `32`, with gesture phase in field `132` and fractional progress in field `119`. The old code only handled legacy DockControl type `30` with HID type `23`, motion field `123`, and progress field `124`, so macOS 27 physical swipes were passed through instead of being replaced by the app's synthetic Dock swipe.

The latest commits address this in four layers:

- `6340f71` makes the active process reinstall its event tap shortly after launch and whenever a sibling InstantSpaceSwitcher copy launches.
- `9a56c63` prevents duplicate app instances from keeping their own swipe taps by terminating sibling InstantSpaceSwitcher processes with the same bundle-id prefix.
- `0cb528a` adds macOS 27 FluidTouchGesture support and requests explicit CoreGraphics listen/post event access.
- `4602184` handles the confirmed macOS 27 generic `type29/hid32` physical swipe path, reads progress from field `119`, keeps source-pid filtering only for legacy `type30`, and registers non-destructive startup defaults.

For local verification, the installed Homebrew login item was also disabled so the old `/Applications` copy will not relaunch on the next reboot.

## Formula

For non-instant velocities:

```text
offset = max(0, requestedVelocity - 40)
baseVelocity = 40 + offset * 0.45 + offset * offset * 0.0175
normalizedVelocity = 40 + (baseVelocity - 40) * (targetHz / baselineHz)
```

The result is capped below Instant. On a baseline 120Hz display:

```text
Normal:  40 -> 40
Fast:    50 -> 46.25
Faster:  60 -> 56
Fastest: 80 -> 86
Instant: 2000 -> 2000
```

On a 240Hz display with 120Hz baseline:

```text
Normal:  40 -> 40
Fast:    50 -> 52.5
Faster:  60 -> 72
Fastest: 80 -> 132
Instant: 2000 -> 2000
```

For phases:

```text
Began progress = FLT_TRUE_MIN
Normal progress = FLT_TRUE_MIN
Fast/Faster/Fastest Changed progress = 0.09
Fast/Faster/Fastest Ended progress = 0.09
```

Instant and high multi-space gestures keep near-zero progress.

## Commit Evolution

- `88459e1` introduced linear refresh-ratio scaling, but this still generated different activation behavior across displays.
- `cc05f92` used Instant velocity for `Ended`; it activated immediately but collapsed every speed option into Instant.
- `2000f2c` restored non-instant animation and added progress, but progress still differed by display because it was derived from refresh-scaled velocity.
- `f6a0cae` removed refresh-dependent gesture generation and normalized all displays onto a shared Dock activation curve.
- `07f681b` widened the non-instant curve, but the upper presets were still too close for perceived speed differences.
- `7f605f6` expanded the upper presets more aggressively, but Fast became too fast.
- `6561c3b` softened the curve and lowered fixed non-instant progress.
- `3d0ec20` slowed the whole non-instant curve further after all presets still felt too fast.
- `8b8b7e5` anchored Normal back to the original raw gesture and halved the remaining fast-preset curve.
- `fe1bd65` applies refresh-rate normalization only to the velocity offset above Normal, using the selected display's UUID.
- `9a4b823`, `510465a`, and `f56c2ea` tried aggressive Ended-phase commit fixes; user testing showed they caused jerky instant-looking transitions.
- `c7a42ac` removes the aggressive Ended override and restores distinct non-instant preset phases.
- `6340f71` fixes the reboot/login-item race by reinstalling the swipe-override event tap after launch and after sibling InstantSpaceSwitcher app launches.
- `9a56c63` prevents duplicate InstantSpaceSwitcher instances from continuing to own global swipe taps.
- `0cb528a` handles macOS 27 FluidTouchGesture swipe events and requests explicit CoreGraphics event listen/post access.
- `4602184` handles macOS 27 generic Gesture/HID32 swipe events and prevents fresh defaults domains from silently disabling swipe override.

## Verification

- current test host: macOS 27.0 (`26A428`)
- physical event probe with app stopped captured the macOS 27 path as type `29`, HID type `32`, phase `132`, progress field `119`
- `swift test --disable-sandbox`: 44 tests passed
- `./dist/build.sh --debug`: universal debug app built successfully
- dev bundle rebuilt and relaunched as `build/InstantSpaceSwitcherDev.app`
- dev bundle uses bundle id `com.interversehq.InstantSpaceSwitcher.dev`, stable Apple Development signing, and `GitCommitHash 4602184`
- `CGGetEventTapList` shows the dev tap enabled with event mask `0xe0000c00`, which includes `29/30/31`
- synthetic macOS27-style `type29/hid32` test event was consumed by the dev app and produced legacy synthetic `type30` events from the dev PID
- menu-triggered synthetic switch still posts legacy type `30` and remains functional
- after reboot diagnosis showed two concurrent app copies:
  - dev PID posted `velocity=46.25`, `progress=0.09` for Fast
  - installed Homebrew PID posted `velocity=2000`, `progress=FLT_TRUE_MIN`, matching the returned instant behavior
- local BTM state has `/Applications/InstantSpaceSwitcher.app` disabled and `build/InstantSpaceSwitcherDev.app` enabled for login
- after manually launching the installed `/Applications` copy while dev was running, the dev app terminated the sibling process; runtime returned to only the dev PID
- unit tests cover 120Hz/240Hz formula outputs and verify `Ended` does not override preset velocity/progress
- unit tests cover macOS 27 event type handling: mask includes `29/30/31`, generic `29/hid32` uses field `119`, legacy `30/31/hid23` uses the Dock swipe path, and only legacy `30` requires kernel source PID
- none of the non-instant presets posts `2000`

Fixes #75
