### PR TITLE
AltGr + Precise KeyMask detection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ISSTests",
-            dependencies: ["ISS"]
+            dependencies: ["ISS", "InstantSpaceSwitcher"]
         )
     ]
 )

--- a/Sources/InstantSpaceSwitcher/Hotkeys/HotKeyManager.swift
+++ b/Sources/InstantSpaceSwitcher/Hotkeys/HotKeyManager.swift
@@ -4,17 +4,19 @@ import Carbon
 class HotKeyManager {
   static let shared = HotKeyManager()
 
-  private struct Registration {
-    let id: UInt32
-    var reference: EventHotKeyRef?
+  private struct Entry {
+    let identifier: HotkeyIdentifier
+    let combination: HotkeyCombination
+    let handler: () -> Void
   }
 
-  private var handlers: [UInt32: () -> Void] = [:]
-  private var registrations: [HotkeyIdentifier: Registration] = [:]
-  private var currentId: UInt32 = 1
+  private var entries: [HotkeyIdentifier: Entry] = [:]
+  private var eventTap: CFMachPort?
+  private var runLoopSource: CFRunLoopSource?
+  private var retryScheduled = false
 
   private init() {
-    installEventHandler()
+    installEventTap()
   }
 
   func register(
@@ -22,59 +24,118 @@ class HotKeyManager {
   ) {
     unregister(identifier: identifier)
 
-    let id = currentId
-    currentId &+= 1
-
-    var hotKeyRef: EventHotKeyRef?
-    let hotKeyID = EventHotKeyID(signature: 0x1111, id: id)
-    let status = RegisterEventHotKey(
-      combination.keyCode, combination.modifiers, hotKeyID, GetEventDispatcherTarget(), 0,
-      &hotKeyRef)
-
-    guard status == noErr else {
-      print("Failed to register hotkey for \(identifier) status=\(status)")
-      return
-    }
-
-    handlers[id] = handler
-    registrations[identifier] = Registration(id: id, reference: hotKeyRef)
+    entries[identifier] = Entry(identifier: identifier, combination: combination, handler: handler)
+    installEventTap()
   }
 
   func unregister(identifier: HotkeyIdentifier) {
-    guard let registration = registrations.removeValue(forKey: identifier) else { return }
-    handlers.removeValue(forKey: registration.id)
-    if let reference = registration.reference {
-      UnregisterEventHotKey(reference)
-    }
+    entries.removeValue(forKey: identifier)
   }
 
   func unregisterAll() {
-    for (_, registration) in registrations {
-      if let reference = registration.reference {
-        UnregisterEventHotKey(reference)
-      }
-    }
-    registrations.removeAll()
-    handlers.removeAll()
+    entries.removeAll()
   }
 
-  private func installEventHandler() {
-    var eventSpec = EventTypeSpec(
-      eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+  private func installEventTap() {
+    if let eventTap {
+      if CFMachPortIsValid(eventTap) {
+        return
+      }
+      self.eventTap = nil
+      runLoopSource = nil
+    }
 
-    InstallEventHandler(
-      GetEventDispatcherTarget(),
-      { (_, event, _) -> OSStatus in
-        var hotKeyID = EventHotKeyID()
-        GetEventParameter(
-          event, EventParamName(kEventParamDirectObject), EventParamType(typeEventHotKeyID), nil,
-          MemoryLayout<EventHotKeyID>.size, nil, &hotKeyID)
+    let eventMask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+    guard
+      let eventTap = CGEvent.tapCreate(
+        tap: .cgSessionEventTap,
+        place: .headInsertEventTap,
+        options: .defaultTap,
+        eventsOfInterest: eventMask,
+        callback: { _, type, event, userInfo in
+          guard let userInfo else { return Unmanaged.passUnretained(event) }
+          let manager = Unmanaged<HotKeyManager>.fromOpaque(userInfo).takeUnretainedValue()
 
-        if let handler = HotKeyManager.shared.handlers[hotKeyID.id] {
-          handler()
-        }
+          if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap = manager.eventTap {
+              CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+          }
 
-        return noErr
-      }, 1, &eventSpec, nil, nil)
+          guard type == .keyDown else {
+            return Unmanaged.passUnretained(event)
+          }
+
+          if manager.dispatch(event: event) {
+            return nil
+          }
+          return Unmanaged.passUnretained(event)
+        },
+        userInfo: Unmanaged.passUnretained(self).toOpaque()
+      )
+    else {
+      print("Failed to install hotkey event tap")
+      scheduleEventTapRetry()
+      return
+    }
+
+    retryScheduled = false
+    self.eventTap = eventTap
+    runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+    if let runLoopSource {
+      CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+    }
+    CGEvent.tapEnable(tap: eventTap, enable: true)
+  }
+
+  private func scheduleEventTapRetry() {
+    guard !retryScheduled else { return }
+    retryScheduled = true
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+      guard let self else { return }
+      self.retryScheduled = false
+      self.installEventTap()
+    }
+  }
+
+  private func dispatch(event: CGEvent) -> Bool {
+    let keyCode = UInt32(event.getIntegerValueField(.keyboardEventKeycode))
+    let rawFlags = event.flags.rawValue
+    let selectedEntry = Self.preferredEntry(from: Array(entries.values), keyCode: keyCode, flags: rawFlags)
+
+    if let selectedEntry {
+      DispatchQueue.main.async {
+        selectedEntry.handler()
+      }
+      return true
+    }
+
+    return false
+  }
+
+  static func preferredCombination(
+    from combinations: [HotkeyCombination], keyCode: UInt32, eventModifierFlags flags: UInt64
+  ) -> HotkeyCombination? {
+    combinations.filter {
+      $0.keyCode == keyCode && $0.matches(eventModifierFlags: flags)
+    }.max {
+      priority(for: $0) < priority(for: $1)
+    }
+  }
+
+  private static func preferredEntry(
+    from entries: [Entry], keyCode: UInt32, flags: UInt64
+  ) -> Entry? {
+    entries.filter {
+      $0.combination.keyCode == keyCode && $0.combination.matches(eventModifierFlags: flags)
+    }.max {
+      priority(for: $0.combination) < priority(for: $1.combination)
+    }
+  }
+
+  private static func priority(for combination: HotkeyCombination) -> Int {
+    combination.optionKeyKind == .right ? 1 : 0
   }
 }

--- a/Sources/InstantSpaceSwitcher/Hotkeys/HotkeyConfiguration.swift
+++ b/Sources/InstantSpaceSwitcher/Hotkeys/HotkeyConfiguration.swift
@@ -2,14 +2,31 @@ import AppKit
 import Carbon
 import Foundation
 
+enum OptionKeyKind: String, Codable {
+  case any
+  case right
+}
+
 struct HotkeyCombination: Codable, Equatable {
   var keyCode: UInt32
   var modifiers: UInt32
   var displayKey: String
   var keyEquivalent: String
+  var optionKeyKind: OptionKeyKind
+
+  init(
+    keyCode: UInt32, modifiers: UInt32, displayKey: String, keyEquivalent: String,
+    optionKeyKind: OptionKeyKind = .any
+  ) {
+    self.keyCode = keyCode
+    self.modifiers = modifiers
+    self.displayKey = displayKey
+    self.keyEquivalent = keyEquivalent
+    self.optionKeyKind = optionKeyKind
+  }
 
   var displayString: String {
-    let modifierSymbols = HotkeyCombination.symbols(for: modifiers)
+    let modifierSymbols = HotkeyCombination.symbols(for: modifiers, optionKeyKind: optionKeyKind)
     return modifierSymbols + displayKey
   }
 
@@ -24,6 +41,43 @@ struct HotkeyCombination: Codable, Equatable {
 
   var isValid: Bool {
     !displayKey.isEmpty
+  }
+
+  var registrationModifiers: UInt32 {
+    modifiers
+  }
+
+  func matches(eventModifierFlags flags: UInt64) -> Bool {
+    guard modifiers == HotkeyModifierState.carbonMask(fromRawFlags: flags) else {
+      return false
+    }
+
+    if optionKeyKind == .right {
+      return HotkeyModifierState.isRightOptionPressed(rawFlags: flags)
+    }
+
+    if modifiers & UInt32(optionKey) != 0 {
+      return !HotkeyModifierState.isRightOptionPressed(rawFlags: flags)
+    }
+
+    return true
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case keyCode
+    case modifiers
+    case displayKey
+    case keyEquivalent
+    case optionKeyKind
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    keyCode = try container.decode(UInt32.self, forKey: .keyCode)
+    modifiers = try container.decode(UInt32.self, forKey: .modifiers)
+    displayKey = try container.decode(String.self, forKey: .displayKey)
+    keyEquivalent = try container.decode(String.self, forKey: .keyEquivalent)
+    optionKeyKind = try container.decodeIfPresent(OptionKeyKind.self, forKey: .optionKeyKind) ?? .any
   }
 
   static let defaultLeft = HotkeyCombination(
@@ -107,6 +161,8 @@ struct HotkeyCombination: Codable, Equatable {
   static func from(event: NSEvent) -> HotkeyCombination? {
     let modifiers = event.modifierFlags.carbonMask
     let keyCode = UInt32(event.keyCode)
+    let optionKeyKind = HotkeyModifierState.optionKeyKind(
+      fromRawFlags: UInt64(event.modifierFlags.rawValue))
     
     // Handle arrow keys
     if let special = event.specialKey, let symbol = arrowSymbol(for: special) {
@@ -114,7 +170,8 @@ struct HotkeyCombination: Codable, Equatable {
         keyCode: keyCode,
         modifiers: modifiers,
         displayKey: symbol,
-        keyEquivalent: arrowKeyEquivalent(special)
+        keyEquivalent: arrowKeyEquivalent(special),
+        optionKeyKind: optionKeyKind
       )
     }
     
@@ -124,7 +181,8 @@ struct HotkeyCombination: Codable, Equatable {
         keyCode: keyCode,
         modifiers: modifiers,
         displayKey: displayKey,
-        keyEquivalent: keyEquiv
+        keyEquivalent: keyEquiv,
+        optionKeyKind: optionKeyKind
       )
     }
 
@@ -138,7 +196,8 @@ struct HotkeyCombination: Codable, Equatable {
       keyCode: keyCode,
       modifiers: modifiers,
       displayKey: upper,
-      keyEquivalent: String(first).lowercased()
+      keyEquivalent: String(first).lowercased(),
+      optionKeyKind: optionKeyKind
     )
   }
 
@@ -224,10 +283,12 @@ struct HotkeyCombination: Codable, Equatable {
     }
   }
 
-  private static func symbols(for modifiers: UInt32) -> String {
+  private static func symbols(for modifiers: UInt32, optionKeyKind: OptionKeyKind) -> String {
     var result = ""
     if modifiers & UInt32(controlKey) != 0 { result += "⌃" }
-    if modifiers & UInt32(optionKey) != 0 { result += "⌥" }
+    if modifiers & UInt32(optionKey) != 0 {
+      result += optionKeyKind == .right ? "AltGr" : "⌥"
+    }
     if modifiers & UInt32(shiftKey) != 0 { result += "⇧" }
     if modifiers & UInt32(cmdKey) != 0 { result += "⌘" }
     return result
@@ -235,6 +296,22 @@ struct HotkeyCombination: Codable, Equatable {
 
   private static var defaultModifierMask: UInt32 {
     UInt32(cmdKey) | UInt32(optionKey) | UInt32(controlKey)
+  }
+}
+
+enum HotkeyModifierState {
+  private static let deviceRightOptionMask: UInt64 = 0x00000040
+
+  static func optionKeyKind(fromRawFlags flags: UInt64) -> OptionKeyKind {
+    isRightOptionPressed(rawFlags: flags) ? .right : .any
+  }
+
+  static func isRightOptionPressed(rawFlags flags: UInt64) -> Bool {
+    flags & deviceRightOptionMask != 0
+  }
+
+  static func carbonMask(fromRawFlags flags: UInt64) -> UInt32 {
+    NSEvent.ModifierFlags(rawValue: UInt(flags)).carbonMask
   }
 }
 

--- a/Sources/InstantSpaceSwitcher/UI/HotkeyPreferencesView.swift
+++ b/Sources/InstantSpaceSwitcher/UI/HotkeyPreferencesView.swift
@@ -240,8 +240,9 @@ final class HotkeyPreferencesView: NSView {
   private func handleRecordingResult(
     _ combination: HotkeyCombination, for identifier: HotkeyIdentifier
   ) {
-    let otherIdentifier = identifier.other
-    if store.combination(for: otherIdentifier) == combination {
+    if let otherIdentifier = HotkeyIdentifier.allCases.first(where: {
+      $0 != identifier && store.combination(for: $0) == combination
+    }) {
       NSSound.beep()
       setStatus("Shortcut already used for \(otherIdentifier.displayName).", color: .systemRed)
       recordingIdentifier = nil
@@ -297,15 +298,5 @@ final class HotkeyPreferencesView: NSView {
   private func setStatus(_ message: String, color: NSColor) {
     statusLabel.stringValue = message
     statusLabel.textColor = color
-  }
-}
-
-extension HotkeyIdentifier {
-  fileprivate var other: HotkeyIdentifier {
-    switch self {
-    case .left: return .right
-    case .right: return .left
-    default: return .left
-    }
   }
 }

--- a/Sources/InstantSpaceSwitcher/UI/KeyboardShortcutsViewController.swift
+++ b/Sources/InstantSpaceSwitcher/UI/KeyboardShortcutsViewController.swift
@@ -253,12 +253,14 @@ extension KeyboardShortcutsViewController: NSTableViewDelegate {
   private func handleRecordingResult(
     _ combination: HotkeyCombination, for identifier: HotkeyIdentifier
   ) {
-    let otherIdentifier: HotkeyIdentifier = identifier == .left ? .right : .left
-    if store.combination(for: otherIdentifier) == combination {
+    if let otherIdentifier = HotkeyIdentifier.allCases.first(where: {
+      $0 != identifier && store.combination(for: $0) == combination
+    }) {
       NSSound.beep()
       let alert = NSAlert()
       alert.messageText = "Shortcut already in use"
-      alert.informativeText = "This shortcut is already assigned to another action."
+      alert.informativeText =
+        "This shortcut is already assigned to \(otherIdentifier.displayName)."
       alert.alertStyle = .warning
       alert.addButton(withTitle: "OK")
       alert.runModal()

--- a/Tests/ISSTests/HotkeyCombinationTests.swift
+++ b/Tests/ISSTests/HotkeyCombinationTests.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Carbon
+@testable import InstantSpaceSwitcher
+import XCTest
+
+final class HotkeyCombinationTests: XCTestCase {
+    private let optionFlags = UInt64(NSEvent.ModifierFlags.option.rawValue)
+    private let controlOptionFlags =
+        UInt64(NSEvent.ModifierFlags([.control, .option]).rawValue)
+    private let rightOptionDeviceFlag: UInt64 = 0x00000040
+
+    func testGenericOptionDoesNotMatchAdditionalControl() {
+        let combination = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1"
+        )
+
+        XCTAssertTrue(combination.matches(eventModifierFlags: optionFlags))
+        XCTAssertFalse(combination.matches(eventModifierFlags: controlOptionFlags))
+    }
+
+    func testGenericOptionDoesNotMatchRightOption() {
+        let combination = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1"
+        )
+
+        XCTAssertFalse(combination.matches(eventModifierFlags: optionFlags | rightOptionDeviceFlag))
+    }
+
+    func testAltGrRequiresRightOption() {
+        let combination = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1",
+            optionKeyKind: .right
+        )
+
+        XCTAssertFalse(combination.matches(eventModifierFlags: optionFlags))
+        XCTAssertTrue(combination.matches(eventModifierFlags: optionFlags | rightOptionDeviceFlag))
+    }
+
+    func testLegacyDecodedShortcutDefaultsToGenericOption() throws {
+        let json = """
+        {
+          "keyCode": \(kVK_ANSI_1),
+          "modifiers": \(optionKey),
+          "displayKey": "1",
+          "keyEquivalent": "1"
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(
+            HotkeyCombination.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.optionKeyKind, .any)
+        XCTAssertFalse(decoded.matches(eventModifierFlags: optionFlags | rightOptionDeviceFlag))
+    }
+
+    func testAltGrDisplayIsDistinctFromGenericOption() {
+        let generic = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1"
+        )
+        let altGr = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1",
+            optionKeyKind: .right
+        )
+
+        XCTAssertEqual(generic.displayString, "⌥1")
+        XCTAssertEqual(altGr.displayString, "AltGr1")
+        XCTAssertNotEqual(generic, altGr)
+    }
+
+    func testAltGrSpecificShortcutWinsOverGenericOption() {
+        let generic = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1"
+        )
+        let altGr = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1",
+            optionKeyKind: .right
+        )
+
+        XCTAssertEqual(
+            HotKeyManager.preferredCombination(
+                from: [generic, altGr],
+                keyCode: UInt32(kVK_ANSI_1),
+                eventModifierFlags: optionFlags | rightOptionDeviceFlag),
+            altGr
+        )
+    }
+
+    func testNoShortcutSelectedForWrongKeyCode() {
+        let combination = HotkeyCombination(
+            keyCode: UInt32(kVK_ANSI_1),
+            modifiers: UInt32(optionKey),
+            displayKey: "1",
+            keyEquivalent: "1"
+        )
+
+        XCTAssertNil(
+            HotKeyManager.preferredCombination(
+                from: [combination],
+                keyCode: UInt32(kVK_ANSI_2),
+                eventModifierFlags: optionFlags)
+        )
+    }
+}


### PR DESCRIPTION
Hey,

I'm using `Alt-1..` for my keybinds and also `Alt-Shift-3` for specific screenshot app. That's when I found that `Alt+<anything>+<N>` is handled by `Alt+<N>`.

Didn't want to bother with a feature request so I made a pull request instead. 

---
## PR contents

### Precise keymap mask handling

So `Alt+N` handles ONLY `Alt+N`, non-matching mask combinations are left unmatched and returned to system dispatcher.

### AltGr recognition

Since I was already at keys, another long standing issue was inability to use AltGr+N keys (which has some helpful symbols like `€`, `§`, `•`, `°` (for 25°C),`‹`, `›`.

So Left Alt/Option is recognized as Alt/Option, Right ALT is recognized as AltGr

**Side effect**: If someone is using LeftAlt+<SOMETHING> and RightAlt+<SOMETHING> this patch will make them unhappy.

## AI-Assisted Contribution Notice

This contribution was produced with substantial assistance from AI (Codex/GPT 5.5).

My personal contribution:
- Directly defined how cases should be handled
- Reviewed output code and making sure the output is sound and change doesn't expand beyond  scope
- Tested (in context of the feature) happy paths and as well as edge cases
- Filled in the paperwork (this PR) 


**I do not claim authorship** because my contribution is too small.
**I take full professional responsibility** for the quality of the final result.

Please treat this as an offer rather than an expectation. If it isn’t a good fit, feel free to close the pull request.